### PR TITLE
Allow user to specify the delay between mouseWheel calls

### DIFF
--- a/API/src/main/java/org/sikuli/script/Mouse.java
+++ b/API/src/main/java/org/sikuli/script/Mouse.java
@@ -46,6 +46,7 @@ public class Mouse {
   public static final int RIGHT = InputEvent.BUTTON3_MASK;
   public static final int WHEEL_UP = -1;
   public static int WHEEL_DOWN = 1;
+  public static int WHEEL_STEP_DELAY = 50;
 
   private Mouse() {
   }
@@ -406,6 +407,10 @@ public class Mouse {
   }
 
   protected static void wheel(int direction, int steps, Region region) {
+    wheel(direction,steps,region, WHEEL_STEP_DELAY);
+  }
+    
+  protected static void wheel(int direction, int steps, Region region, int stepDelay) {
     if (get().device.isSuspended()) {
       return;
     }
@@ -415,7 +420,7 @@ public class Mouse {
             (direction == WHEEL_UP ? "WHEEL_UP" : "WHEEL_DOWN"), steps);
     for (int i = 0; i < steps; i++) {
       r.mouseWheel(direction);
-      r.delay(50);
+      r.delay(stepDelay);
     }
     get().device.let(region);
   }

--- a/API/src/main/java/org/sikuli/script/Mouse.java
+++ b/API/src/main/java/org/sikuli/script/Mouse.java
@@ -46,7 +46,7 @@ public class Mouse {
   public static final int RIGHT = InputEvent.BUTTON3_MASK;
   public static final int WHEEL_UP = -1;
   public static int WHEEL_DOWN = 1;
-  public static int WHEEL_STEP_DELAY = 50;
+  public static final int WHEEL_STEP_DELAY = 50;
 
   private Mouse() {
   }

--- a/API/src/main/java/org/sikuli/script/Region.java
+++ b/API/src/main/java/org/sikuli/script/Region.java
@@ -3826,12 +3826,28 @@ public class Region {
    * @throws FindFailed if the Find operation failed
    */
   public <PFRML> int wheel(PFRML target, int direction, int steps) throws FindFailed {
+    return wheel(target, direction, steps, Mouse.WHEEL_STEP_DELAY);
+  }
+    
+  /**
+   * move the mouse pointer to the given target location<br> and move the wheel the given steps in the given direction:
+   * <br>Button.WHEEL_DOWN, Button.WHEEL_UP
+   *
+   * @param <PFRML> Pattern, Filename, Text, Region, Match or Location target
+   * @param target Pattern, Filename, Text, Region, Match or Location
+   * @param direction to move the wheel
+   * @param steps the number of steps
+   * @param stepDelay number of miliseconds to wait when incrementing the step value
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed if the Find operation failed
+   */
+  public <PFRML> int wheel(PFRML target, int direction, int steps, int stepDelay) throws FindFailed {
     Location loc = getLocationFromTarget(target);
     if (loc != null) {
       Mouse.use(this);
       Mouse.keep(this);
       Mouse.move(loc, this);
-      Mouse.wheel(direction, steps, this);
+      Mouse.wheel(direction, steps, this, stepDelay);
       Mouse.let(this);
       return 1;
     }


### PR DESCRIPTION
The 50ms delay between mouseWheel calls was to much of a delay on the chrome emulator. We have some pull to refresh panels in our application that were not working correctly because the pull was to slow. I added an override for the wheel method to specify a delay.