### PR TITLE
remove not working "switchTo" Call on windows from App initialization

### DIFF
--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -268,21 +268,22 @@ public class App {
     if (appPID > -1) {
       Debug.log(3, "App.create: %s", toStringShort());
     } else {
-      if (runTime.runningWindows) {
-        if (!isImmediate && appOptions.isEmpty()) {
-          int pid = _osUtil.switchto(appNameGiven);
-          if (pid > 0) {
-            init(pid);
-            appWindow = "!" + appNameGiven;
-            Debug.log(3, "App.create: %s", toStringShort());
-          } else {
-            appPID = -1;
-            appName = "";
-          }
-        }
-      } else {
+//      if (runTime.runningWindows) {
+//        if (!isImmediate && appOptions.isEmpty()) {
+////          int pid = -1;
+//          int pid = _osUtil.switchto(appNameGiven);
+//          if (pid > 0) {
+//            init(pid);
+//            appWindow = "!" + appNameGiven;
+//            Debug.log(3, "App.create: %s", toStringShort());
+//          } else {
+//            appPID = -1;
+//            appName = "";
+//          }
+//        }
+//      } else {
         appName = new File(appNameGiven).getName();
-      }
+//      }
     }
   }
 


### PR DESCRIPTION
Unfortunately the following code will cause some trouble since the `_osUtil.switchto(appNameGiven);` statement have been added:

``` java
// Only on Windows!
App myApp = new App("appname.exe");
myApp.open();
//... do some other stuff
myApp.close; // => App won't close and will stand open!
```

As far as I can understand the code and my debugging results, the problem is that the native call of `_osUtil.switchto(appNameGiven);` in the constructor `new App("...")` will not just tries to __switch__ the app. It furthermore will __always __ open the App if there is no one in the background. In my opinion this behavior is incorrect. I would expect only the call `myApp.open()` will open an Application. Also I would prefer if the behavior on Windows is the same as on Linux.  

I uncomment the code which is OS-dependent and all works fine for me. Maybe this part of the code is obsolete.  Hope this contribute some helpful stuff to your great project!

Best regards!