### PR TITLE
adding are more strict way for the sanity check of OS dependent libraries

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -29,6 +29,11 @@
 			<version>1.2</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-exec</artifactId>
+			<version>1.3</version>
+		</dependency>
+		<dependency>
 			<groupId>com.melloware</groupId>
 			<artifactId>jintellitype</artifactId>
 			<version>1.3.9</version>

--- a/API/src/main/java/org/sikuli/natives/LinuxUtil.java
+++ b/API/src/main/java/org/sikuli/natives/LinuxUtil.java
@@ -77,7 +77,7 @@ public class LinuxUtil implements OSUtil {
       byte pidBytes[] = new byte[64];
       int len = in.read(pidBytes);
       String pidStr = new String(pidBytes, 0, len);
-      int pid = Integer.parseInt(new String(pidStr));
+      int pid = Integer.parseInt(pidStr);
       p.waitFor();
       return pid;
       //return p.exitValue();
@@ -132,6 +132,9 @@ public class LinuxUtil implements OSUtil {
 
   @Override
   public int close(App.AppEntry app) {
+    if (app.pid > 0) {
+      return close(app.pid);
+    }
     return close(app.execName);
   }
 
@@ -141,11 +144,10 @@ public class LinuxUtil implements OSUtil {
   }
 
   private enum SearchType {
-
     APP_NAME,
     WINDOW_ID,
     PID
-  };
+  }
 
   @Override
   public Rectangle getFocusedWindow() {
@@ -175,7 +177,7 @@ public class LinuxUtil implements OSUtil {
 
   private Rectangle findRegion(String appName, int winNum, SearchType type) {
     String[] winLine = findWindow(appName, winNum, type);
-    if (winLine.length >= 7) {
+    if (winLine != null && winLine.length >= 7) {
       int x = new Integer(winLine[3]);
       int y = Integer.parseInt(winLine[4]);
       int w = Integer.parseInt(winLine[5]);
@@ -239,7 +241,7 @@ public class LinuxUtil implements OSUtil {
             }
           }
 
-          if (!ok && winLine[7].toLowerCase().indexOf(appName) >= 0) {
+          if (!ok && winLine[7].toLowerCase().contains(appName)) {
             ok = true;
           }
         }

--- a/API/src/main/java/org/sikuli/natives/MacUtil.java
+++ b/API/src/main/java/org/sikuli/natives/MacUtil.java
@@ -6,13 +6,13 @@
  */
 package org.sikuli.natives;
 
-import java.awt.Rectangle;
-import java.awt.Window;
-import java.util.Map;
-import javax.swing.JOptionPane;
 import org.sikuli.script.App;
 import org.sikuli.script.RunTime;
 import org.sikuli.script.Runner;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Map;
 
 public class MacUtil implements OSUtil {
 
@@ -21,10 +21,12 @@ public class MacUtil implements OSUtil {
   private static RunTime runTime = null;
 
 	@Override
-	public String getLibName() {
-    runTime = RunTime.get();
-		return "MacUtil";
-	}
+    public void checkLibAvailability() {
+      runTime = RunTime.get();
+      if (runTime == null) {
+        throw new NativeCommandException("Native runtime environment isn't setup correctly!");
+      }
+    }
 
   /*
   tell application "System Events"

--- a/API/src/main/java/org/sikuli/natives/NativeCommandException.java
+++ b/API/src/main/java/org/sikuli/natives/NativeCommandException.java
@@ -1,0 +1,13 @@
+package org.sikuli.natives;
+
+/**
+ * Wrapper for all Exception which occurs during native command execution.
+ *
+ * @author tschneck
+ *         Date: 9/15/15
+ */
+public class NativeCommandException extends RuntimeException {
+    public NativeCommandException(String s) {
+        super(s);
+    }
+}

--- a/API/src/main/java/org/sikuli/natives/OSUtil.java
+++ b/API/src/main/java/org/sikuli/natives/OSUtil.java
@@ -6,17 +6,22 @@
  */
 package org.sikuli.natives;
 
-import java.awt.Rectangle;
-import java.awt.Window;
-import java.util.Map;
 import org.sikuli.script.App;
+
+import java.awt.*;
+import java.util.Map;
 
 public interface OSUtil {
   // Windows: returns PID, 0 if fails
   // Others: return 0 if succeeds, -1 if fails
 
-	public String getLibName();
-  
+  /**
+   * make a sanity check if all needed native command libraries or packages are installed.
+   *
+   * @throws NativeCommandException if some library is missing
+   */
+  void checkLibAvailability() throws NativeCommandException;
+
   public App.AppEntry getApp(int pid, String name);
 
   public Map<Integer, String[]> getApps(String name);

--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -6,22 +6,22 @@
  */
 package org.sikuli.natives;
 
-import java.awt.Rectangle;
-import java.awt.Window;
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 import org.sikuli.basics.Debug;
 import org.sikuli.script.App;
 import org.sikuli.script.Key;
 import org.sikuli.script.RunTime;
 import org.sikuli.script.Screen;
 
+import java.awt.*;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
 public class WinUtil implements OSUtil {
 
   @Override
-  public String getLibName() {
-    return "WinUtil";
+  public void checkLibAvailability() {
+    //currently not needed
   }
 
   @Override

--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -6,28 +6,19 @@
  */
 package org.sikuli.script;
 
-import java.awt.Desktop;
-import java.awt.Rectangle;
 import org.sikuli.basics.Debug;
-import java.awt.Toolkit;
-import java.awt.datatransfer.ClipboardOwner;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringReader;
+import org.sikuli.natives.OSUtil;
+import org.sikuli.natives.SysUtil;
+
+import java.awt.*;
+import java.awt.datatransfer.*;
+import java.io.*;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import org.sikuli.natives.OSUtil;
-import org.sikuli.natives.SysUtil;
 
 /**
  * App implements features to manage (open, switch to, close) applications.
@@ -56,10 +47,8 @@ public class App {
   static {
 //TODO Sikuli hangs if App is used before Screen
     new Screen();
-		String libName = _osUtil.getLibName();
-		if (!libName.isEmpty()) {
-			RunTime.loadLibrary(libName);
-		}
+    _osUtil.checkLibAvailability();
+
     appsWindows = new HashMap<Type, String>();
     appsWindows.put(Type.EDITOR, "Notepad");
     appsWindows.put(Type.BROWSER, "Google Chrome");


### PR DESCRIPTION
Due to the fact, that I had often forgot to install some native libraries or packages in my Linux installations, I added more strict implementation of the sanity check. 

Also I used the more reliable `commons-exec` framework to execute the native commands, due to the better configuration and error handling behavior. Maybe this hint will be also helpful for you.

Furthermore it implements the `LinuxUtil#closeApp` method like the `MacUtil` and `WinUtil`