### PR TITLE
enable utf8 typing and make sikuli independent of the host keyboard layout 

### DIFF
--- a/API/src/main/java/org/sikuli/basics/HotkeyManager.java
+++ b/API/src/main/java/org/sikuli/basics/HotkeyManager.java
@@ -6,15 +6,13 @@
  */
 package org.sikuli.basics;
 
+import org.sikuli.script.keyboard.KeyPress;
+import org.sikuli.script.keyboard.KeyboardDelegator;
+
 import java.awt.event.KeyEvent;
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.Map;
-import org.sikuli.basics.Debug;
-import org.sikuli.basics.PreferencesUser;
-import org.sikuli.basics.Settings;
-import org.sikuli.script.Key;
-import org.sikuli.script.Key;
 
 /**
  * Singleton class to bind hotkeys to hotkey listeners
@@ -179,8 +177,8 @@ public abstract class HotkeyManager {
    * @return true if success. false otherwise.
    */
   public boolean addHotkey(String key, int modifiers, HotkeyListener callback) {
-    int[] keyCodes = Key.toJavaKeyCode(key.toLowerCase());
-    int keyCode = keyCodes[0];
+    KeyPress keyPress = KeyboardDelegator.toJavaKeyCode(key.toLowerCase().charAt(0));
+    int keyCode = keyPress != null ? keyPress.getKeys()[0] : null;
     return installHotkey(keyCode, modifiers, callback, "");
   }
 
@@ -257,8 +255,8 @@ public abstract class HotkeyManager {
    * @return true if success. false otherwise.
    */
   public boolean removeHotkey(String key, int modifiers) {
-    int[] keyCodes = Key.toJavaKeyCode(key.toLowerCase());
-    int keyCode = keyCodes[0];
+    KeyPress keyPress = KeyboardDelegator.toJavaKeyCode(key.toLowerCase().charAt(0));
+    int keyCode = keyPress != null ? keyPress.getKeys()[0] : null;
     return uninstallHotkey(keyCode, modifiers, "");
   }
 

--- a/API/src/main/java/org/sikuli/natives/CommandExecutorHelper.java
+++ b/API/src/main/java/org/sikuli/natives/CommandExecutorHelper.java
@@ -1,0 +1,35 @@
+package org.sikuli.natives;
+
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.PumpStreamHandler;
+
+import java.io.ByteArrayOutputStream;
+
+public class CommandExecutorHelper {
+
+    public static CommandExecutorResult execute(String commandString, int expectedExitValue) throws Exception {
+        ByteArrayOutputStream error = new ByteArrayOutputStream();
+        ByteArrayOutputStream stout = new ByteArrayOutputStream();
+        CommandLine cmd = CommandLine.parse(commandString);
+        try {
+            DefaultExecutor executor = new DefaultExecutor();
+            executor.setExitValue(expectedExitValue);
+            executor.setStreamHandler(new PumpStreamHandler(stout, error));
+            //if exit value != expectedExitValue => Exception
+            int exitValue = executor.execute(cmd);
+            return new CommandExecutorResult(exitValue, stout.toString(), error.toString());
+
+        } catch (Exception e) {
+            int exitValue = -1;
+            if (e instanceof ExecuteException) {
+                exitValue = ((ExecuteException) e).getExitValue();
+            }
+            throw new NativeCommandException(
+                    "error in command " + cmd.toString(),
+                    new CommandExecutorResult(exitValue, stout.toString(), error.toString()));
+        }
+    }
+
+}

--- a/API/src/main/java/org/sikuli/natives/CommandExecutorResult.java
+++ b/API/src/main/java/org/sikuli/natives/CommandExecutorResult.java
@@ -1,0 +1,25 @@
+package org.sikuli.natives;
+
+public class CommandExecutorResult {
+    private int exitValue;
+    private String errorOutput;
+    private String standardOutput;
+
+    public CommandExecutorResult(int exitValue, String standardOutput, String errorOutput) {
+        this.exitValue = exitValue;
+        this.errorOutput = errorOutput;
+        this.standardOutput = standardOutput;
+    }
+
+    public int getExitValue() {
+        return exitValue;
+    }
+
+    public String getErrorOutput() {
+        return errorOutput;
+    }
+
+    public String getStandardOutput() {
+        return standardOutput;
+    }
+}

--- a/API/src/main/java/org/sikuli/natives/NativeCommandException.java
+++ b/API/src/main/java/org/sikuli/natives/NativeCommandException.java
@@ -1,0 +1,44 @@
+package org.sikuli.natives;
+
+/**
+ * Wrapper for all Exception which occurs during native command execution.
+ *
+ * @author tschneck
+ *         Date: 9/15/15
+ */
+public class NativeCommandException extends RuntimeException {
+    private final CommandExecutorResult commandExecutorResult;
+
+    public NativeCommandException(String message) {
+        super(message);
+        this.commandExecutorResult = null;
+    }
+
+    public NativeCommandException(String message, CommandExecutorResult commandExecutorResult) {
+        super(message);
+        this.commandExecutorResult = commandExecutorResult;
+    }
+
+    public CommandExecutorResult getCommandExecutorResult() {
+        return commandExecutorResult;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder("[error] ");
+        if (super.getMessage() != null) {
+            sb.append(super.getMessage());
+        }
+        if (commandExecutorResult != null) {
+            String stout = commandExecutorResult.getStandardOutput();
+            if (stout != null && !stout.isEmpty()) {
+                sb.append("\n[stout] ").append(stout);
+            }
+            String errorOutput = commandExecutorResult.getErrorOutput();
+            if (errorOutput != null && !errorOutput.isEmpty()) {
+                sb.append("\n[errout] ").append(errorOutput);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/API/src/main/java/org/sikuli/natives/OSUtil.java
+++ b/API/src/main/java/org/sikuli/natives/OSUtil.java
@@ -62,4 +62,10 @@ public interface OSUtil {
   public Rectangle getFocusedWindow();
 
   public void bringWindowToFront(Window win, boolean ignoreMouse);
+
+  boolean isUtf8InputSupported();
+
+  int[] getUnicodeModifier();
+
+  String getUnicodeKeyInputString(int key);
 }

--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -345,7 +345,7 @@ public class WinUtil implements OSUtil {
       String keyCombo;
       if (isUtf8InputSupported()) {
           //use hex value as input
-          keyCombo = String.format("%04x", key);
+          keyCombo = String.format("%x", key);
           Debug.log(4, "determined unicode: 0x" + keyCombo);
       } else {
           if(key > 255) {

--- a/API/src/main/java/org/sikuli/script/Key.java
+++ b/API/src/main/java/org/sikuli/script/Key.java
@@ -6,15 +6,18 @@
  */
 package org.sikuli.script;
 
-import org.sikuli.basics.HotkeyManager;
+import org.sikuli.basics.Debug;
 import org.sikuli.basics.HotkeyListener;
-import java.awt.Toolkit;
+import org.sikuli.basics.HotkeyManager;
+import org.sikuli.basics.Settings;
+import org.sikuli.script.keyboard.KeyPress;
+import org.sikuli.script.keyboard.KeyboardDelegator;
+
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import org.sikuli.basics.Debug;
-import org.sikuli.basics.Settings;
 
 /**
  * this class implements an interface to the Java key system
@@ -24,246 +27,6 @@ import org.sikuli.basics.Settings;
  * for details consult the docs
  */
 public class Key {
-
-  /**
-   * add a hotkey and listener
-   * @param key respective key specifier according class Key
-   * @param modifiers respective key specifier according class KeyModifiers
-   * @param listener a HotKeyListener instance
-   * @return true if ok, false otherwise
-   */
-  public static boolean addHotkey(String key, int modifiers, HotkeyListener listener) {
-    return HotkeyManager.getInstance().addHotkey(key, modifiers, listener);
-  }
-
-  /**
-   * add a hotkey and listener
-   * @param key respective key specifier according class Key
-   * @param modifiers respective key specifier according class KeyModifiers
-   * @param listener a HotKeyListener instance
-   * @return true if ok, false otherwise
-   */
-  public static boolean addHotkey(char key, int modifiers, HotkeyListener listener) {
-    return HotkeyManager.getInstance().addHotkey(key, modifiers, listener);
-  }
-
-  /**
-   * remove a hotkey and listener
-   * @param key respective key specifier according class Key
-   * @param modifiers respective key specifier according class KeyModifiers
-   * @return true if ok, false otherwise
-   */
-  public static boolean removeHotkey(String key, int modifiers) {
-    return HotkeyManager.getInstance().removeHotkey(key, modifiers);
-  }
-
-  /**
-   * remove a hotkey and listener
-   * @param key respective key specifier according class Key
-   * @param modifiers respective key specifier according class KeyModifiers
-   * @return true if ok, false otherwise
-   */
-  public static boolean removeHotkey(char key, int modifiers) {
-    return HotkeyManager.getInstance().removeHotkey(key, modifiers);
-  }
-
-  static String[] keyVK = new String[] {
-  //<editor-fold defaultstate="collapsed" desc="VK_xxx constant names and values Java 7">
-    "VK_0","48",
-    "VK_1","49",
-    "VK_2","50",
-    "VK_3","51",
-    "VK_4","52",
-    "VK_5","53",
-    "VK_6","54",
-    "VK_7","55",
-    "VK_8","56",
-    "VK_9","57",
-    "VK_A","65",
-    "VK_ACCEPT","30",
-    "VK_ADD","107",
-    "VK_AGAIN","65481",
-    "VK_ALL_CANDIDATES","256",
-    "VK_ALPHANUMERIC","240",
-    "VK_ALT","18",
-    "VK_ALT_GRAPH","65406",
-    "VK_AMPERSAND","150",
-    "VK_ASTERISK","151",
-    "VK_AT","512",
-    "VK_B","66",
-    "VK_BACK_QUOTE","192",
-    "VK_BACK_SLASH","92",
-    "VK_BACK_SPACE","8",
-    "VK_BEGIN","65368",
-    "VK_BRACELEFT","161",
-    "VK_BRACERIGHT","162",
-    "VK_C","67",
-    "VK_CANCEL","3",
-    "VK_CAPS_LOCK","20",
-    "VK_CIRCUMFLEX","514",
-    "VK_CLEAR","12",
-    "VK_CLOSE_BRACKET","93",
-    "VK_CODE_INPUT","258",
-    "VK_COLON","513",
-    "VK_COMMA","44",
-    "VK_COMPOSE","65312",
-    "VK_CONTEXT_MENU","525",
-    "VK_CONTROL","17",
-    "VK_CONVERT","28",
-    "VK_COPY","65485",
-    "VK_CUT","65489",
-    "VK_D","68",
-    "VK_DEAD_ABOVEDOT","134",
-    "VK_DEAD_ABOVERING","136",
-    "VK_DEAD_ACUTE","129",
-    "VK_DEAD_BREVE","133",
-    "VK_DEAD_CARON","138",
-    "VK_DEAD_CEDILLA","139",
-    "VK_DEAD_CIRCUMFLEX","130",
-    "VK_DEAD_DIAERESIS","135",
-    "VK_DEAD_DOUBLEACUTE","137",
-    "VK_DEAD_GRAVE","128",
-    "VK_DEAD_IOTA","141",
-    "VK_DEAD_MACRON","132",
-    "VK_DEAD_OGONEK","140",
-    "VK_DEAD_SEMIVOICED_SOUND","143",
-    "VK_DEAD_TILDE","131",
-    "VK_DEAD_VOICED_SOUND","142",
-    "VK_DECIMAL","110",
-    "VK_DELETE","127",
-    "VK_DIVIDE","111",
-    "VK_DOLLAR","515",
-    "VK_DOWN","40",
-    "VK_E","69",
-    "VK_END","35",
-    "VK_ENTER","10",
-    "VK_EQUALS","61",
-    "VK_ESCAPE","27",
-    "VK_EURO_SIGN","516",
-    "VK_EXCLAMATION_MARK","517",
-    "VK_F","70",
-    "VK_F1","112",
-    "VK_F10","121",
-    "VK_F11","122",
-    "VK_F12","123",
-    "VK_F13","61440",
-    "VK_F14","61441",
-    "VK_F15","61442",
-    "VK_F16","61443",
-    "VK_F17","61444",
-    "VK_F18","61445",
-    "VK_F19","61446",
-    "VK_F2","113",
-    "VK_F20","61447",
-    "VK_F21","61448",
-    "VK_F22","61449",
-    "VK_F23","61450",
-    "VK_F24","61451",
-    "VK_F3","114",
-    "VK_F4","115",
-    "VK_F5","116",
-    "VK_F6","117",
-    "VK_F7","118",
-    "VK_F8","119",
-    "VK_F9","120",
-    "VK_FINAL","24",
-    "VK_FIND","65488",
-    "VK_FULL_WIDTH","243",
-    "VK_G","71",
-    "VK_GREATER","160",
-    "VK_H","72",
-    "VK_HALF_WIDTH","244",
-    "VK_HELP","156",
-    "VK_HIRAGANA","242",
-    "VK_HOME","36",
-    "VK_I","73",
-    "VK_INPUT_METHOD_ON_OFF","263",
-    "VK_INSERT","155",
-    "VK_INVERTED_EXCLAMATION_MARK","518",
-    "VK_J","74",
-    "VK_JAPANESE_HIRAGANA","260",
-    "VK_JAPANESE_KATAKANA","259",
-    "VK_JAPANESE_ROMAN","261",
-    "VK_K","75",
-    "VK_KANA","21",
-    "VK_KANA_LOCK","262",
-    "VK_KANJI","25",
-    "VK_KATAKANA","241",
-    "VK_KP_DOWN","225",
-    "VK_KP_LEFT","226",
-    "VK_KP_RIGHT","227",
-    "VK_KP_UP","224",
-    "VK_L","76",
-    "VK_LEFT","37",
-    "VK_LEFT_PARENTHESIS","519",
-    "VK_LESS","153",
-    "VK_M","77",
-    "VK_META","157",
-    "VK_MINUS","45",
-    "VK_MODECHANGE","31",
-    "VK_MULTIPLY","106",
-    "VK_N","78",
-    "VK_NONCONVERT","29",
-    "VK_NUM_LOCK","144",
-    "VK_NUMBER_SIGN","520",
-    "VK_NUMPAD0","96",
-    "VK_NUMPAD1","97",
-    "VK_NUMPAD2","98",
-    "VK_NUMPAD3","99",
-    "VK_NUMPAD4","100",
-    "VK_NUMPAD5","101",
-    "VK_NUMPAD6","102",
-    "VK_NUMPAD7","103",
-    "VK_NUMPAD8","104",
-    "VK_NUMPAD9","105",
-    "VK_O","79",
-    "VK_OPEN_BRACKET","91",
-    "VK_P","80",
-    "VK_PAGE_DOWN","34",
-    "VK_PAGE_UP","33",
-    "VK_PASTE","65487",
-    "VK_PAUSE","19",
-    "VK_PERIOD","46",
-    "VK_PLUS","521",
-    "VK_PREVIOUS_CANDIDATE","257",
-    "VK_PRINTSCREEN","154",
-    "VK_PROPS","65482",
-    "VK_Q","81",
-    "VK_QUOTE","222",
-    "VK_QUOTEDBL","152",
-    "VK_R","82",
-    "VK_RIGHT","39",
-    "VK_RIGHT_PARENTHESIS","522",
-    "VK_ROMAN_CHARACTERS","245",
-    "VK_S","83",
-    "VK_SCROLL_LOCK","145",
-    "VK_SEMICOLON","59",
-    "VK_SEPARATER","108",
-    "VK_SEPARATOR","108",
-    "VK_SHIFT","16",
-    "VK_SLASH","47",
-    "VK_SPACE","32",
-    "VK_STOP","65480",
-    "VK_SUBTRACT","109",
-    "VK_T","84",
-    "VK_TAB","9",
-    "VK_U","85",
-    "VK_UNDEFINED","0",
-    "VK_UNDERSCORE","523",
-    "VK_UNDO","65483",
-    "VK_UP","38",
-    "VK_V","86",
-    "VK_W","87",
-    "VK_WINDOWS","524",
-    "VK_X","88",
-    "VK_Y","89",
-    "VK_Z","90"
-  //</editor-fold>
-  };
-
-  // non function keys on US-Keyboard per line top down without modifier keys
-  public static String keyboardUS =
-          "1234567890-=" + "qwertyuiop[]" + "asdfghjkl;'\\" + "`zxcvbnm,./";
 
   //<editor-fold defaultstate="collapsed" desc="KeyNames to UniCode (used in type() with Key.XXX)">
   public static final String SPACE = " ";
@@ -382,13 +145,208 @@ public class Key {
   public static final char C_CONTEXT = '\ue041'; // VK_CONTEXT_MENU
   public static final String NEXT = "\ue043";
   public static final char C_NEXT = '\ue043'; // VK_CONTEXT_MENU
-
   public static final char cMax = '\ue050';
   public static final char cMin = '\ue000';
+  // non function keys on US-Keyboard per line top down without modifier keys
+  public static String keyboardUS =
+          "1234567890-=" + "qwertyuiop[]" + "asdfghjkl;'\\" + "`zxcvbnm,./";
   public static int keyMaxLength;
-//</editor-fold>
-
-  private static Map<String, Integer> keyTexts = new HashMap<String, Integer>();
+  static String[] keyVK = new String[]{
+          //<editor-fold defaultstate="collapsed" desc="VK_xxx constant names and values Java 7">
+          "VK_0", "48",
+          "VK_1", "49",
+          "VK_2", "50",
+          "VK_3", "51",
+          "VK_4", "52",
+          "VK_5", "53",
+          "VK_6", "54",
+          "VK_7", "55",
+          "VK_8", "56",
+          "VK_9", "57",
+          "VK_A", "65",
+          "VK_ACCEPT", "30",
+          "VK_ADD", "107",
+          "VK_AGAIN", "65481",
+          "VK_ALL_CANDIDATES", "256",
+          "VK_ALPHANUMERIC", "240",
+          "VK_ALT", "18",
+          "VK_ALT_GRAPH", "65406",
+          "VK_AMPERSAND", "150",
+          "VK_ASTERISK", "151",
+          "VK_AT", "512",
+          "VK_B", "66",
+          "VK_BACK_QUOTE", "192",
+          "VK_BACK_SLASH", "92",
+          "VK_BACK_SPACE", "8",
+          "VK_BEGIN", "65368",
+          "VK_BRACELEFT", "161",
+          "VK_BRACERIGHT", "162",
+          "VK_C", "67",
+          "VK_CANCEL", "3",
+          "VK_CAPS_LOCK", "20",
+          "VK_CIRCUMFLEX", "514",
+          "VK_CLEAR", "12",
+          "VK_CLOSE_BRACKET", "93",
+          "VK_CODE_INPUT", "258",
+          "VK_COLON", "513",
+          "VK_COMMA", "44",
+          "VK_COMPOSE", "65312",
+          "VK_CONTEXT_MENU", "525",
+          "VK_CONTROL", "17",
+          "VK_CONVERT", "28",
+          "VK_COPY", "65485",
+          "VK_CUT", "65489",
+          "VK_D", "68",
+          "VK_DEAD_ABOVEDOT", "134",
+          "VK_DEAD_ABOVERING", "136",
+          "VK_DEAD_ACUTE", "129",
+          "VK_DEAD_BREVE", "133",
+          "VK_DEAD_CARON", "138",
+          "VK_DEAD_CEDILLA", "139",
+          "VK_DEAD_CIRCUMFLEX", "130",
+          "VK_DEAD_DIAERESIS", "135",
+          "VK_DEAD_DOUBLEACUTE", "137",
+          "VK_DEAD_GRAVE", "128",
+          "VK_DEAD_IOTA", "141",
+          "VK_DEAD_MACRON", "132",
+          "VK_DEAD_OGONEK", "140",
+          "VK_DEAD_SEMIVOICED_SOUND", "143",
+          "VK_DEAD_TILDE", "131",
+          "VK_DEAD_VOICED_SOUND", "142",
+          "VK_DECIMAL", "110",
+          "VK_DELETE", "127",
+          "VK_DIVIDE", "111",
+          "VK_DOLLAR", "515",
+          "VK_DOWN", "40",
+          "VK_E", "69",
+          "VK_END", "35",
+          "VK_ENTER", "10",
+          "VK_EQUALS", "61",
+          "VK_ESCAPE", "27",
+          "VK_EURO_SIGN", "516",
+          "VK_EXCLAMATION_MARK", "517",
+          "VK_F", "70",
+          "VK_F1", "112",
+          "VK_F10", "121",
+          "VK_F11", "122",
+          "VK_F12", "123",
+          "VK_F13", "61440",
+          "VK_F14", "61441",
+          "VK_F15", "61442",
+          "VK_F16", "61443",
+          "VK_F17", "61444",
+          "VK_F18", "61445",
+          "VK_F19", "61446",
+          "VK_F2", "113",
+          "VK_F20", "61447",
+          "VK_F21", "61448",
+          "VK_F22", "61449",
+          "VK_F23", "61450",
+          "VK_F24", "61451",
+          "VK_F3", "114",
+          "VK_F4", "115",
+          "VK_F5", "116",
+          "VK_F6", "117",
+          "VK_F7", "118",
+          "VK_F8", "119",
+          "VK_F9", "120",
+          "VK_FINAL", "24",
+          "VK_FIND", "65488",
+          "VK_FULL_WIDTH", "243",
+          "VK_G", "71",
+          "VK_GREATER", "160",
+          "VK_H", "72",
+          "VK_HALF_WIDTH", "244",
+          "VK_HELP", "156",
+          "VK_HIRAGANA", "242",
+          "VK_HOME", "36",
+          "VK_I", "73",
+          "VK_INPUT_METHOD_ON_OFF", "263",
+          "VK_INSERT", "155",
+          "VK_INVERTED_EXCLAMATION_MARK", "518",
+          "VK_J", "74",
+          "VK_JAPANESE_HIRAGANA", "260",
+          "VK_JAPANESE_KATAKANA", "259",
+          "VK_JAPANESE_ROMAN", "261",
+          "VK_K", "75",
+          "VK_KANA", "21",
+          "VK_KANA_LOCK", "262",
+          "VK_KANJI", "25",
+          "VK_KATAKANA", "241",
+          "VK_KP_DOWN", "225",
+          "VK_KP_LEFT", "226",
+          "VK_KP_RIGHT", "227",
+          "VK_KP_UP", "224",
+          "VK_L", "76",
+          "VK_LEFT", "37",
+          "VK_LEFT_PARENTHESIS", "519",
+          "VK_LESS", "153",
+          "VK_M", "77",
+          "VK_META", "157",
+          "VK_MINUS", "45",
+          "VK_MODECHANGE", "31",
+          "VK_MULTIPLY", "106",
+          "VK_N", "78",
+          "VK_NONCONVERT", "29",
+          "VK_NUM_LOCK", "144",
+          "VK_NUMBER_SIGN", "520",
+          "VK_NUMPAD0", "96",
+          "VK_NUMPAD1", "97",
+          "VK_NUMPAD2", "98",
+          "VK_NUMPAD3", "99",
+          "VK_NUMPAD4", "100",
+          "VK_NUMPAD5", "101",
+          "VK_NUMPAD6", "102",
+          "VK_NUMPAD7", "103",
+          "VK_NUMPAD8", "104",
+          "VK_NUMPAD9", "105",
+          "VK_O", "79",
+          "VK_OPEN_BRACKET", "91",
+          "VK_P", "80",
+          "VK_PAGE_DOWN", "34",
+          "VK_PAGE_UP", "33",
+          "VK_PASTE", "65487",
+          "VK_PAUSE", "19",
+          "VK_PERIOD", "46",
+          "VK_PLUS", "521",
+          "VK_PREVIOUS_CANDIDATE", "257",
+          "VK_PRINTSCREEN", "154",
+          "VK_PROPS", "65482",
+          "VK_Q", "81",
+          "VK_QUOTE", "222",
+          "VK_QUOTEDBL", "152",
+          "VK_R", "82",
+          "VK_RIGHT", "39",
+          "VK_RIGHT_PARENTHESIS", "522",
+          "VK_ROMAN_CHARACTERS", "245",
+          "VK_S", "83",
+          "VK_SCROLL_LOCK", "145",
+          "VK_SEMICOLON", "59",
+          "VK_SEPARATER", "108",
+          "VK_SEPARATOR", "108",
+          "VK_SHIFT", "16",
+          "VK_SLASH", "47",
+          "VK_SPACE", "32",
+          "VK_STOP", "65480",
+          "VK_SUBTRACT", "109",
+          "VK_T", "84",
+          "VK_TAB", "9",
+          "VK_U", "85",
+          "VK_UNDEFINED", "0",
+          "VK_UNDERSCORE", "523",
+          "VK_UNDO", "65483",
+          "VK_UP", "38",
+          "VK_V", "86",
+          "VK_W", "87",
+          "VK_WINDOWS", "524",
+          "VK_X", "88",
+          "VK_Y", "89",
+          "VK_Z", "90"
+          //</editor-fold>
+  };
+  //<editor-fold defaultstate="collapsed" desc="keyboard setup - INTERNAL USE ONLY">
+  static String[] result = new String[]{""};
+  private static Map<String, KeyPress> keyTexts = new HashMap<String, KeyPress>();
   private static Map<Integer, String> keys = new HashMap<Integer, String>();
 
   static {
@@ -397,45 +355,92 @@ public class Key {
     keyMaxLength = 0;
     for (char c = cMin; c < cMax; c++) {
       sKey = toJavaKeyCodeText(c);
-      if (!sKey.equals(""+c)) {
-        keyTexts.put(sKey, toJavaKeyCode(c)[0]);
+      if (!sKey.equals("" + c)) {
+        keyTexts.put(sKey, KeyboardDelegator.toJavaKeyCode(c));
         keyMaxLength = sKey.length() > keyMaxLength ? sKey.length() : keyMaxLength;
       }
     }
-    keyTexts.put("#ENTER.", toJavaKeyCode('\n')[0]);
-    keyTexts.put("#N.", toJavaKeyCode('\n')[0]);
-    keyTexts.put("#BACK.", toJavaKeyCode('\b')[0]);
-    keyTexts.put("#B.", toJavaKeyCode('\b')[0]);
-    keyTexts.put("#TAB.", toJavaKeyCode('\t')[0]);
-    keyTexts.put("#T.", toJavaKeyCode('\t')[0]);
-    keyTexts.put("#X.", toJavaKeyCode(C_NEXT)[0]);
-    keyTexts.put("#ESC.", toJavaKeyCode(C_ESC)[0]);
-    keyTexts.put("#U.", toJavaKeyCode(C_UP)[0]);
-    keyTexts.put("#D.", toJavaKeyCode(C_DOWN)[0]);
-    keyTexts.put("#L.", toJavaKeyCode(C_LEFT)[0]);
-    keyTexts.put("#R.", toJavaKeyCode(C_RIGHT)[0]);
-    keyTexts.put("#S.", toJavaKeyCode(C_SHIFT)[0]);
-    keyTexts.put("#S+", toJavaKeyCode(C_SHIFT)[0]);
-    keyTexts.put("#S-", toJavaKeyCode(C_SHIFT)[0]);
-    keyTexts.put("#A.", toJavaKeyCode(C_ALT)[0]);
-    keyTexts.put("#A+", toJavaKeyCode(C_ALT)[0]);
-    keyTexts.put("#A-", toJavaKeyCode(C_ALT)[0]);
-    keyTexts.put("#C.", toJavaKeyCode(C_CTRL)[0]);
-    keyTexts.put("#C+", toJavaKeyCode(C_CTRL)[0]);
-    keyTexts.put("#C-", toJavaKeyCode(C_CTRL)[0]);
-    keyTexts.put("#M.", toJavaKeyCode(C_META)[0]);
-    keyTexts.put("#M+", toJavaKeyCode(C_META)[0]);
-    keyTexts.put("#M-", toJavaKeyCode(C_META)[0]);
+    keyTexts.put("#ENTER.", KeyboardDelegator.toJavaKeyCode('\n'));
+    keyTexts.put("#N.", KeyboardDelegator.toJavaKeyCode('\n'));
+    keyTexts.put("#BACK.", KeyboardDelegator.toJavaKeyCode('\b'));
+    keyTexts.put("#B.", KeyboardDelegator.toJavaKeyCode('\b'));
+    keyTexts.put("#TAB.", KeyboardDelegator.toJavaKeyCode('\t'));
+    keyTexts.put("#T.", KeyboardDelegator.toJavaKeyCode('\t'));
+    keyTexts.put("#X.", KeyboardDelegator.toJavaKeyCode(C_NEXT));
+    keyTexts.put("#ESC.", KeyboardDelegator.toJavaKeyCode(C_ESC));
+    keyTexts.put("#U.", KeyboardDelegator.toJavaKeyCode(C_UP));
+    keyTexts.put("#D.", KeyboardDelegator.toJavaKeyCode(C_DOWN));
+    keyTexts.put("#L.", KeyboardDelegator.toJavaKeyCode(C_LEFT));
+    keyTexts.put("#R.", KeyboardDelegator.toJavaKeyCode(C_RIGHT));
+    keyTexts.put("#S.", KeyboardDelegator.toJavaKeyCode(C_SHIFT));
+    keyTexts.put("#S+", KeyboardDelegator.toJavaKeyCode(C_SHIFT));
+    keyTexts.put("#S-", KeyboardDelegator.toJavaKeyCode(C_SHIFT));
+    keyTexts.put("#A.", KeyboardDelegator.toJavaKeyCode(C_ALT));
+    keyTexts.put("#A+", KeyboardDelegator.toJavaKeyCode(C_ALT));
+    keyTexts.put("#A-", KeyboardDelegator.toJavaKeyCode(C_ALT));
+    keyTexts.put("#C.", KeyboardDelegator.toJavaKeyCode(C_CTRL));
+    keyTexts.put("#C+", KeyboardDelegator.toJavaKeyCode(C_CTRL));
+    keyTexts.put("#C-", KeyboardDelegator.toJavaKeyCode(C_CTRL));
+    keyTexts.put("#M.", KeyboardDelegator.toJavaKeyCode(C_META));
+    keyTexts.put("#M+", KeyboardDelegator.toJavaKeyCode(C_META));
+    keyTexts.put("#M-", KeyboardDelegator.toJavaKeyCode(C_META));
     for (String k : keyTexts.keySet()) {
       if (Debug.getDebugLevel() > 3) {
-        Debug.log(4, "Key: %s is: %s", k, KeyEvent.getKeyText(keyTexts.get(k)));
+        Debug.log(4, "Key: %s transformed to keypress event %s", k, keyTexts.get(k));
       }
       if (k.length() < 4) {
         continue;
       }
-      keys.put(keyTexts.get(k), k);
+      keys.put(keyTexts.get(k).getKeys()[0], k);
     }
     //</editor-fold>
+  }
+//</editor-fold>
+
+  /**
+   * add a hotkey and listener
+   *
+   * @param key       respective key specifier according class Key
+   * @param modifiers respective key specifier according class KeyModifiers
+   * @param listener  a HotKeyListener instance
+   * @return true if ok, false otherwise
+   */
+  public static boolean addHotkey(String key, int modifiers, HotkeyListener listener) {
+    return HotkeyManager.getInstance().addHotkey(key, modifiers, listener);
+  }
+
+  /**
+   * add a hotkey and listener
+   *
+   * @param key       respective key specifier according class Key
+   * @param modifiers respective key specifier according class KeyModifiers
+   * @param listener  a HotKeyListener instance
+   * @return true if ok, false otherwise
+   */
+  public static boolean addHotkey(char key, int modifiers, HotkeyListener listener) {
+    return HotkeyManager.getInstance().addHotkey(key, modifiers, listener);
+  }
+
+  /**
+   * remove a hotkey and listener
+   *
+   * @param key       respective key specifier according class Key
+   * @param modifiers respective key specifier according class KeyModifiers
+   * @return true if ok, false otherwise
+   */
+  public static boolean removeHotkey(String key, int modifiers) {
+    return HotkeyManager.getInstance().removeHotkey(key, modifiers);
+  }
+
+  /**
+   * remove a hotkey and listener
+   *
+   * @param key       respective key specifier according class Key
+   * @param modifiers respective key specifier according class KeyModifiers
+   * @return true if ok, false otherwise
+   */
+  public static boolean removeHotkey(char key, int modifiers) {
+    return HotkeyManager.getInstance().removeHotkey(key, modifiers);
   }
 
   //<editor-fold defaultstate="collapsed" desc="support functions for write()">
@@ -459,237 +464,37 @@ public class Key {
   }
 
   public static boolean isModifier(String token) {
-    if (toJavaKeyCodeFromText(token) == toJavaKeyCodeFromText("#S.") ||
-        toJavaKeyCodeFromText(token) == toJavaKeyCodeFromText("#C.") ||
-        toJavaKeyCodeFromText(token) == toJavaKeyCodeFromText("#A.") ||
-        toJavaKeyCodeFromText(token) == toJavaKeyCodeFromText("#M.")) {
-      return true;
-    }
-    return false;
+    return token.equals("#S.") ||
+            token.equals("#C.") ||
+            token.equals("#A.") ||
+            token.equals("#M.");
   }
 
   public static int toJavaKeyCodeFromText(String key) {
-    if (null == keyTexts.get(key)) {
-      return -1;
-    } else {
-      return keyTexts.get(key).intValue();
-    }
+    KeyPress keyPress = keyTexts.get(key);
+    return (keyPress == null) ? null : keyPress.getKeys()[0];
   }
-  
+
+  public static KeyPress toJavaKeyPressCodeFromText(String key) {
+      return keyTexts.get(key);
+  }
+  //</editor-fold>
+
   public static void dump() {
     Map<Integer, String> namesVK = new HashMap<Integer, String>();
     for (int i = 0; i < keyVK.length; i += 2) {
-      namesVK.put(Integer.decode(keyVK[i+1]), keyVK[i].substring(3));
+      namesVK.put(Integer.decode(keyVK[i + 1]), keyVK[i].substring(3));
     }
-    Map<String, Integer> sortedNames = new TreeMap<String, Integer>(keyTexts);
+    Map<String, KeyPress> sortedNames = new TreeMap<String, KeyPress>(keyTexts);
     System.out.println("[info] Key: dump keynames (tokens) used with Region write");
     System.out.println("[info] Token to use --- KeyEvent::keycode --- KeyEvent::keyname");
     int keyN;
     for (String key : sortedNames.keySet()) {
-      keyN = sortedNames.get(key);
+      keyN = sortedNames.get(key).getKeys()[0];
       if (keyN < 1) {
         continue;
       }
-      System.out.println(String.format("%s = %d (%s)", key, keyN, namesVK.get(keyN)));      
-    }
-  }
-  //</editor-fold>
-
-  /**
-   * Convert Sikuli Key to Java virtual key code
-	 * @param key as String
-	 * @return the Java KeyCodes
-   */
-  public static int[] toJavaKeyCode(String key) {
-    if (key.length() > 0) {
-      return toJavaKeyCode(key.charAt(0));
-    }
-    return null;
-  }
-
-  /**
-   * Convert Sikuli Key to Java virtual key code
-	 * @param key as Character
-	 * @return the Java KeyCodes
-   */
-  public static int[] toJavaKeyCode(char key) {
-    switch (key) {
-//Lowercase
-      case 'a': return new int[]{KeyEvent.VK_A};
-      case 'b': return new int[]{KeyEvent.VK_B};
-      case 'c': return new int[]{KeyEvent.VK_C};
-      case 'd': return new int[]{KeyEvent.VK_D};
-      case 'e': return new int[]{KeyEvent.VK_E};
-      case 'f': return new int[]{KeyEvent.VK_F};
-      case 'g': return new int[]{KeyEvent.VK_G};
-      case 'h': return new int[]{KeyEvent.VK_H};
-      case 'i': return new int[]{KeyEvent.VK_I};
-      case 'j': return new int[]{KeyEvent.VK_J};
-      case 'k': return new int[]{KeyEvent.VK_K};
-      case 'l': return new int[]{KeyEvent.VK_L};
-      case 'm': return new int[]{KeyEvent.VK_M};
-      case 'n': return new int[]{KeyEvent.VK_N};
-      case 'o': return new int[]{KeyEvent.VK_O};
-      case 'p': return new int[]{KeyEvent.VK_P};
-      case 'q': return new int[]{KeyEvent.VK_Q};
-      case 'r': return new int[]{KeyEvent.VK_R};
-      case 's': return new int[]{KeyEvent.VK_S};
-      case 't': return new int[]{KeyEvent.VK_T};
-      case 'u': return new int[]{KeyEvent.VK_U};
-      case 'v': return new int[]{KeyEvent.VK_V};
-      case 'w': return new int[]{KeyEvent.VK_W};
-      case 'x': return new int[]{KeyEvent.VK_X};
-      case 'y': return new int[]{KeyEvent.VK_Y};
-      case 'z': return new int[]{KeyEvent.VK_Z};
-//Uppercase
-      case 'A': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_A};
-      case 'B': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_B};
-      case 'C': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_C};
-      case 'D': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_D};
-      case 'E': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_E};
-      case 'F': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_F};
-      case 'G': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_G};
-      case 'H': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_H};
-      case 'I': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_I};
-      case 'J': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_J};
-      case 'K': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_K};
-      case 'L': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_L};
-      case 'M': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_M};
-      case 'N': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_N};
-      case 'O': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_O};
-      case 'P': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_P};
-      case 'Q': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_Q};
-      case 'R': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_R};
-      case 'S': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_S};
-      case 'T': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_T};
-      case 'U': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_U};
-      case 'V': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_V};
-      case 'W': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_W};
-      case 'X': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_X};
-      case 'Y': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_Y};
-      case 'Z': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_Z};
-//Row 3 (below function keys)
-//      case '§': return new int[]{192}; //not producable
-      case '1': return new int[]{KeyEvent.VK_1};
-      case '!': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_1};
-      case '2': return new int[]{KeyEvent.VK_2};
-      case '@': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_2};
-      case '3': return new int[]{KeyEvent.VK_3};
-      case '#': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_3};
-      case '4': return new int[]{KeyEvent.VK_4};
-      case '$': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_4};
-      case '5': return new int[]{KeyEvent.VK_5};
-      case '%': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_5};
-      case '6': return new int[]{KeyEvent.VK_6};
-      case '^': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_6};
-      case '7': return new int[]{KeyEvent.VK_7};
-      case '&': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_7};
-      case '8': return new int[]{KeyEvent.VK_8};
-      case '*': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_8};
-      case '9': return new int[]{KeyEvent.VK_9};
-      case '(': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_9};
-      case '0': return new int[]{KeyEvent.VK_0};
-      case ')': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_0};
-      case '-': return new int[]{KeyEvent.VK_MINUS};
-      case '_': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_MINUS};
-      case '=': return new int[]{KeyEvent.VK_EQUALS};
-      case '+': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_EQUALS};
-//Row 2
-// q w e r t y u i o p
-      case '[': return new int[]{KeyEvent.VK_OPEN_BRACKET};
-      case '{': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_OPEN_BRACKET};
-      case ']': return new int[]{KeyEvent.VK_CLOSE_BRACKET};
-      case '}': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_CLOSE_BRACKET};
-//Row 1
-// a s d f g h j k l
-      case ';': return new int[]{KeyEvent.VK_SEMICOLON};
-      case ':': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_SEMICOLON};
-      case '\'': return new int[]{KeyEvent.VK_QUOTE};
-      case '"': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_QUOTE};
-      case '\\': return new int[]{KeyEvent.VK_BACK_SLASH};
-      case '|': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_BACK_SLASH};
-//RETURN, BACKSPACE, TAB
-      case '\b': return new int[]{KeyEvent.VK_BACK_SPACE};
-      case '\t': return new int[]{KeyEvent.VK_TAB};
-      case '\r': return new int[]{KeyEvent.VK_ENTER};
-      case '\n': return new int[]{KeyEvent.VK_ENTER};
-//SPACE
-      case ' ': return new int[]{KeyEvent.VK_SPACE};
-//Row 0 (first above SPACE)
-      case '`': return new int[]{KeyEvent.VK_BACK_QUOTE};
-      case '~': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_BACK_QUOTE};
-// z x c v b n m
-      case ',': return new int[]{KeyEvent.VK_COMMA};
-      case '<': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_COMMA};
-      case '.': return new int[]{KeyEvent.VK_PERIOD};
-      case '>': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_PERIOD};
-      case '/': return new int[]{KeyEvent.VK_SLASH};
-      case '?': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_SLASH};
-//Modifier
-      case Key.C_SHIFT: return new int[]{KeyEvent.VK_SHIFT};
-      case Key.C_CTRL:  return new int[]{KeyEvent.VK_CONTROL};
-      case Key.C_ALT:   return new int[]{KeyEvent.VK_ALT};
-      case Key.C_META:  return new int[]{KeyEvent.VK_META};
-//Cursor movement
-      case Key.C_UP:     return new int[]{KeyEvent.VK_UP};
-      case Key.C_RIGHT:     return new int[]{KeyEvent.VK_RIGHT};
-      case Key.C_DOWN:      return new int[]{KeyEvent.VK_DOWN};
-      case Key.C_LEFT:      return new int[]{KeyEvent.VK_LEFT};
-      case Key.C_PAGE_UP:   return new int[]{KeyEvent.VK_PAGE_UP};
-      case Key.C_PAGE_DOWN: return new int[]{KeyEvent.VK_PAGE_DOWN};
-      case Key.C_END:       return new int[]{KeyEvent.VK_END};
-      case Key.C_HOME:      return new int[]{KeyEvent.VK_HOME};
-      case Key.C_DELETE:    return new int[]{KeyEvent.VK_DELETE};
-//Function keys
-      case Key.C_ESC: return new int[]{KeyEvent.VK_ESCAPE};
-      case Key.C_F1:  return new int[]{KeyEvent.VK_F1};
-      case Key.C_F2:  return new int[]{KeyEvent.VK_F2};
-      case Key.C_F3:  return new int[]{KeyEvent.VK_F3};
-      case Key.C_F4:  return new int[]{KeyEvent.VK_F4};
-      case Key.C_F5:  return new int[]{KeyEvent.VK_F5};
-      case Key.C_F6:  return new int[]{KeyEvent.VK_F6};
-      case Key.C_F7:  return new int[]{KeyEvent.VK_F7};
-      case Key.C_F8:  return new int[]{KeyEvent.VK_F8};
-      case Key.C_F9:  return new int[]{KeyEvent.VK_F9};
-      case Key.C_F10: return new int[]{KeyEvent.VK_F10};
-      case Key.C_F11: return new int[]{KeyEvent.VK_F11};
-      case Key.C_F12: return new int[]{KeyEvent.VK_F12};
-      case Key.C_F13: return new int[]{KeyEvent.VK_F13};
-      case Key.C_F14: return new int[]{KeyEvent.VK_F14};
-      case Key.C_F15: return new int[]{KeyEvent.VK_F15};
-//Toggling kezs
-      case Key.C_SCROLL_LOCK: return new int[]{KeyEvent.VK_SCROLL_LOCK};
-      case Key.C_NUM_LOCK:    return new int[]{KeyEvent.VK_NUM_LOCK};
-      case Key.C_CAPS_LOCK:   return new int[]{KeyEvent.VK_CAPS_LOCK};
-      case Key.C_INSERT:      return new int[]{KeyEvent.VK_INSERT};
-//Windows special
-      case Key.C_PAUSE:       return new int[]{KeyEvent.VK_PAUSE};
-      case Key.C_PRINTSCREEN: return new int[]{KeyEvent.VK_PRINTSCREEN};
-//Num pad
-      case Key.C_NUM0: return new int[]{KeyEvent.VK_NUMPAD0};
-      case Key.C_NUM1: return new int[]{KeyEvent.VK_NUMPAD1};
-      case Key.C_NUM2: return new int[]{KeyEvent.VK_NUMPAD2};
-      case Key.C_NUM3: return new int[]{KeyEvent.VK_NUMPAD3};
-      case Key.C_NUM4: return new int[]{KeyEvent.VK_NUMPAD4};
-      case Key.C_NUM5: return new int[]{KeyEvent.VK_NUMPAD5};
-      case Key.C_NUM6: return new int[]{KeyEvent.VK_NUMPAD6};
-      case Key.C_NUM7: return new int[]{KeyEvent.VK_NUMPAD7};
-      case Key.C_NUM8: return new int[]{KeyEvent.VK_NUMPAD8};
-      case Key.C_NUM9: return new int[]{KeyEvent.VK_NUMPAD9};
-//Num pad special
-      case Key.C_SEPARATOR: return new int[]{KeyEvent.VK_SEPARATOR};
-      case Key.C_ADD:       return new int[]{KeyEvent.VK_ADD};
-      case Key.C_MINUS:     return new int[]{KeyEvent.VK_SUBTRACT};
-      case Key.C_MULTIPLY:  return new int[]{KeyEvent.VK_MULTIPLY};
-      case Key.C_DIVIDE:    return new int[]{KeyEvent.VK_DIVIDE};
-      case Key.C_DECIMAL:   return new int[]{KeyEvent.VK_DECIMAL};
-      case Key.C_CONTEXT:   return new int[]{KeyEvent.VK_CONTEXT_MENU};
-      case Key.C_WIN:   return new int[]{KeyEvent.VK_WINDOWS};
-//hack: alternative tab in GUI
-      case Key.C_NEXT:   return new int[]{-KeyEvent.VK_TAB};
-
-      default:
-        throw new IllegalArgumentException("Cannot convert character " + key);
+      System.out.println(String.format("%s = %d (%s)", key, keyN, namesVK.get(keyN)));
     }
   }
 
@@ -827,9 +632,6 @@ public class Key {
       return KeyEvent.VK_CONTROL;
     }
   }
-
-  //<editor-fold defaultstate="collapsed" desc="keyboard setup - INTERNAL USE ONLY">
-  static String[] result = new String[] {""};
 
   /**
    * INTERNAL USE ONLY
@@ -1040,11 +842,12 @@ public class Key {
       String k1 = "...";
       String k2 = "...";
       try {
-        if (toJavaKeyCode((ckey)).length > 1) {
-                  k1 = namesVK.get(new Integer(toJavaKeyCode(ckey)[0]).toString());
-                  k2 = namesVK.get(new Integer(toJavaKeyCode(ckey)[1]).toString());
+          int[] keys = KeyboardDelegator.toJavaKeyCode(ckey).getKeys();
+          if (keys.length > 1) {
+          k1 = namesVK.get(new Integer(keys[0]).toString());
+          k2 = namesVK.get(new Integer(keys[1]).toString());
         } else if (key > 32) {
-          k2 = namesVK.get(new Integer(toJavaKeyCode(ckey)[0]).toString());
+          k2 = namesVK.get(new Integer(keys[0]).toString());
         }
       } catch (Exception e) {      }
       keyText = KeyEvent.getKeyText(key);
@@ -1068,13 +871,9 @@ public class Key {
       if (vkey == null || vkey.equals(keyText.toUpperCase())) {
         vkey = "...";
       }
-      if (null == getTextFromKeycode(key)) {
-        Debug.log(3, form, key, keyText.toUpperCase(),
-                vkey, "...", k2, k1);
-      } else {
-        Debug.log(3, form, key, keyText.toUpperCase(),
-                vkey, getTextFromKeycode(key), k2, k1);
-      }
+      String textFromKeycode = getTextFromKeycode(key);
+      Debug.log(3, form, key, keyText.toUpperCase(), vkey,
+              (textFromKeycode == null) ? "..." : textFromKeycode, k2, k1);
     }
   }
   //</editor-fold>

--- a/API/src/main/java/org/sikuli/script/Key.java
+++ b/API/src/main/java/org/sikuli/script/Key.java
@@ -385,13 +385,15 @@ public class Key {
     keyTexts.put("#M+", KeyboardDelegator.toJavaKeyCode(C_META));
     keyTexts.put("#M-", KeyboardDelegator.toJavaKeyCode(C_META));
     for (String k : keyTexts.keySet()) {
+      KeyPress keyPress = keyTexts.get(k);
       if (Debug.getDebugLevel() > 3) {
-        Debug.log(4, "Key: %s transformed to keypress event %s", k, keyTexts.get(k));
+        Debug.log(4, "Key: %s transformed to keypress event %s", k, keyPress);
       }
       if (k.length() < 4) {
         continue;
       }
-      keys.put(keyTexts.get(k).getKeys()[0], k);
+      //get key if present, if not use modifier
+      keys.put(keyPress.getKeys().length > 0 ? keyPress.getKeys()[0] : keyPress.getModifiers()[0], k);
     }
     //</editor-fold>
   }

--- a/API/src/main/java/org/sikuli/script/KeyModifier.java
+++ b/API/src/main/java/org/sikuli/script/KeyModifier.java
@@ -6,12 +6,15 @@
  */
 package org.sikuli.script;
 
+import org.sikuli.basics.Settings;
+
 import java.awt.event.InputEvent;
 
 /**
  * complementing class Key with the constants for the modifier keys<br>
  * only still there for backward compatibility (is already duplicated in Key)
  */
+@Deprecated
 public class KeyModifier {
    public static final int CTRL = InputEvent.CTRL_MASK;
    public static final int SHIFT = InputEvent.SHIFT_MASK;
@@ -33,5 +36,29 @@ public class KeyModifier {
    public static final int KEY_CMD = InputEvent.META_MASK;
    @Deprecated
    public static final int KEY_WIN = InputEvent.META_MASK;
+
+   @Deprecated
+   public static char lookUpKey(int keyModifier){
+      char key = 0;
+      switch (keyModifier) {
+         case SHIFT:
+            key = Key.C_SHIFT;
+            break;
+         case CTRL:
+            key = Key.C_CTRL;
+            break;
+         case ALT:
+            key = Key.C_ALT;
+            break;
+         case META:
+            if (Settings.isWindows()) {
+               key = Key.C_WIN;
+            } else {
+               key = Key.C_META;
+            }
+            break;
+      }
+      return key;
+   }
 }
 

--- a/API/src/main/java/org/sikuli/script/Region.java
+++ b/API/src/main/java/org/sikuli/script/Region.java
@@ -6,21 +6,17 @@
  */
 package org.sikuli.script;
 
+import edu.unh.iol.dlc.VNCScreen;
+import org.sikuli.basics.Debug;
+import org.sikuli.basics.Settings;
 import org.sikuli.util.ScreenHighlighter;
-import java.awt.Rectangle;
+
+import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
-import java.util.Date;
-import java.util.Iterator;
+import java.util.*;
 import java.util.List;
-import org.sikuli.basics.Debug;
-import org.sikuli.basics.Settings;
-
-import edu.unh.iol.dlc.VNCScreen;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 
 /**
  * A Region is a rectengular area and lies always completely inside its parent screen
@@ -266,7 +262,7 @@ public class Region {
           }
         }
       }
-    } 
+    }
     if (screenOn != null) {
       x = screenRect.x;
       y = screenRect.y;
@@ -286,8 +282,8 @@ public class Region {
     }
     return loc.setOtherScreen(scr);
   }
-  
-  public static Region virtual(Rectangle rect) {    
+
+  public static Region virtual(Rectangle rect) {
     Region reg = new Region();
     reg.x = rect.x;
     reg.y = rect.y;
@@ -297,10 +293,10 @@ public class Region {
     reg.scr = Screen.getPrimaryScreen();
     return reg;
   }
-  
+
   /**
    * INTERNAL USE - EXPERIMENTAL
-   * if true: this region is not bound to any screen 
+   * if true: this region is not bound to any screen
    * @return the current state
    */
   public boolean isVirtual() {
@@ -309,7 +305,7 @@ public class Region {
 
   /**
    * INTERNAL USE - EXPERIMENTAL
-   * @param state if true: this region is not bound to any screen 
+   * @param state if true: this region is not bound to any screen
    */
   public void setVirtual(boolean state) {
     isVirtual = state;
@@ -425,7 +421,7 @@ public class Region {
   public Region(Region r) {
     init(r);
   }
-  
+
   public void init(Region r) {
     if (!r.isValid()) {
       return;
@@ -824,7 +820,7 @@ public class Region {
     if (getScreen() == null || isScreenUnion) {
       return Screen.getPrimaryScreen().getRobot();
     }
-    return getScreen().getRobot(); 
+    return getScreen().getRobot();
   }
 
   /**
@@ -1357,7 +1353,7 @@ public class Region {
   public boolean contains(Region region) {
     return getRect().contains(region.getRect());
   }
-  
+
   /**
    * create a Location object, that can be used as an offset taking the width and hight of this Region
    * @return a new Location object with width and height as x and y
@@ -1950,7 +1946,7 @@ public class Region {
       highlight(true, null);
     }
   }
-  
+
   protected Region silentHighlight(boolean onOff) {
     if (onOff && overlay == null) {
       return doHighlight(true, null, true);
@@ -2277,7 +2273,7 @@ public class Region {
       }
     }
   }
-  
+
   public <PSI> Match[] findAllByRow(PSI target) {
     Match[] matches = new Match[0];
     List<Match> mList = findAllCollect(target);
@@ -2328,7 +2324,7 @@ public class Region {
     }
     return mList;
   }
-  
+
   public <PSI> Match findBest(Object... args) {
     Debug.log(lvl, "findBest: enter");
     Match mResult = null;
@@ -2387,17 +2383,17 @@ public class Region {
     }
     return mList;
   }
-  
+
   private class SubFindRun implements Runnable {
-    
+
     Match[] mArray;
     ScreenImage base;
     Object target;
     Region reg;
     boolean finished = false;
     int subN;
-    
-    public SubFindRun(Match[] pMArray, int pSubN, 
+
+    public SubFindRun(Match[] pMArray, int pSubN,
             ScreenImage pBase, Object pTarget, Region pReg) {
       subN = pSubN;
       base = pBase;
@@ -2405,7 +2401,7 @@ public class Region {
       reg = pReg;
       mArray = pMArray;
     }
-    
+
     @Override
     public void run() {
       try {
@@ -2415,11 +2411,11 @@ public class Region {
       }
       hasFinished(true);
     }
-    
+
     public boolean hasFinished() {
       return hasFinished(false);
-    }    
-    
+    }
+
     public synchronized boolean hasFinished(boolean state) {
       if (state) {
         finished = true;
@@ -2427,7 +2423,7 @@ public class Region {
       return finished;
     }
   }
-  
+
   private Match findInImage(ScreenImage base, Object target) throws IOException {
     Finder finder = null;
     Match match = null;
@@ -2487,7 +2483,7 @@ public class Region {
     }
     return match;
   }
-  
+
   /**
    * Waits for the Pattern, String or Image to appear until the AutoWaitTimeout value is exceeded.
    *
@@ -2720,7 +2716,7 @@ public class Region {
     boolean findingText = false;
     lastFindTime = (new Date()).getTime();
     ScreenImage simg;
-    double findTimeout = autoWaitTimeout; 
+    double findTimeout = autoWaitTimeout;
     if (repeating != null) {
       findTimeout = repeating.getFindTimeOut();
     }
@@ -2730,9 +2726,9 @@ public class Region {
       f.setScreenImage(simg);
       f.setRepeating();
       if (Settings.FindProfiling) {
-        Debug.logp("[FindProfiling] Region.doFind repeat: %d msec", 
+        Debug.logp("[FindProfiling] Region.doFind repeat: %d msec",
                 new Date().getTime() - lastSearchTimeRepeat);
-      }      
+      }
       lastSearchTime = (new Date()).getTime();
       f.findRepeat();
     } else {
@@ -2805,11 +2801,11 @@ public class Region {
       m.setTimes(lastFindTime, lastSearchTime);
       if (Settings.FindProfiling) {
         Debug.logp("[FindProfiling] Region.doFind final: %d msec", lastSearchTime);
-      }      
+      }
     }
     return m;
   }
-  
+
   private void runFinder(Finder f, Object target) {
     if (Debug.shouldHighlight()) {
       if (this.scr.getW() > w + 20 && this.scr.getH() > h + 20)
@@ -2825,14 +2821,14 @@ public class Region {
   private Finder checkLastSeenAndCreateFinder(Image img, double findTimeout, Pattern ptn) {
     return doCheckLastSeenAndCreateFinder(null, img, findTimeout, ptn);
   }
-  
+
   private Finder doCheckLastSeenAndCreateFinder(ScreenImage base, Image img, double findTimeout, Pattern ptn) {
     if (base == null) {
       base = getScreen().capture(this);
     }
     if (!Settings.UseImageFinder && Settings.CheckLastSeen && null != img.getLastSeen()) {
       Region r = Region.create(img.getLastSeen());
-      float score = (float) (img.getLastSeenScore() - 0.01); 
+      float score = (float) (img.getLastSeenScore() - 0.01);
       if (this.contains(r)) {
         Finder f = null;
         if (this.scr instanceof VNCScreen) {
@@ -2842,7 +2838,7 @@ public class Region {
           if (Debug.shouldHighlight()) {
             if (this.scr.getW() > w + 10 && this.scr.getH() > h + 10)
               highlight(2, "#000255000");
-          }          
+          }
         }
         if (ptn == null) {
           f.find(new Pattern(img).similar(score));
@@ -2864,7 +2860,7 @@ public class Region {
       return new Finder(base, this);
     }
   }
-  
+
   public void saveLastScreenImage() {
     ScreenImage simg = getScreen().getLastScreenImageFromScreen();
     if (simg != null) {
@@ -2969,7 +2965,7 @@ public class Region {
           return false;
         }
         long after_find = (new Date()).getTime();
-        if (after_find - before_find < MaxTimePerScan) {          
+        if (after_find - before_find < MaxTimePerScan) {
           getRobotForRegion().delay((int) (MaxTimePerScan - (after_find - before_find)));
         } else {
           getRobotForRegion().delay(10);
@@ -3692,7 +3688,7 @@ public class Region {
     Settings.DelayBeforeMouseDown = Settings.DelayValue;
     Settings.DelayAfterDrag = Settings.DelayValue;
     Settings.DelayBeforeDrag = -Settings.DelayValue;
-    Settings.DelayBeforeDrop = Settings.DelayValue; 
+    Settings.DelayBeforeDrop = Settings.DelayValue;
     return retVal;
   }
 
@@ -3705,7 +3701,7 @@ public class Region {
    * @return 1 if possible, 0 otherwise
    * @throws FindFailed if not found
    */
-  public <PFRML> int drag(PFRML target) throws FindFailed {    
+  public <PFRML> int drag(PFRML target) throws FindFailed {
     Location loc = getLocationFromTarget(target);
     int retVal = 0;
     if (loc != null) {
@@ -3728,7 +3724,7 @@ public class Region {
     Settings.DelayBeforeMouseDown = Settings.DelayValue;
     Settings.DelayAfterDrag = Settings.DelayValue;
     Settings.DelayBeforeDrag = -Settings.DelayValue;
-    Settings.DelayBeforeDrop = Settings.DelayValue; 
+    Settings.DelayBeforeDrop = Settings.DelayValue;
     return retVal;
   }
 
@@ -3760,7 +3756,7 @@ public class Region {
     Settings.DelayBeforeMouseDown = Settings.DelayValue;
     Settings.DelayAfterDrag = Settings.DelayValue;
     Settings.DelayBeforeDrag = -Settings.DelayValue;
-    Settings.DelayBeforeDrop = Settings.DelayValue; 
+    Settings.DelayBeforeDrop = Settings.DelayValue;
     return retVal;
   }
   //</editor-fold>
@@ -3864,7 +3860,7 @@ public class Region {
   public <PFRML> int wheel(PFRML target, int direction, int steps) throws FindFailed {
     return wheel(target, direction, steps, Mouse.WHEEL_STEP_DELAY);
   }
-    
+
   /**
    * move the mouse pointer to the given target location<br> and move the wheel the given steps in the given direction:
    * <br>Button.WHEEL_DOWN, Button.WHEEL_UP
@@ -4228,12 +4224,12 @@ public class Region {
       Settings.TypeDelay = 0.0;
       profiler.lap("before typing");
       r.typeStarts();
+      r.pressModifiers(modifiers);
       for (int i = 0; i < text.length(); i++) {
-        r.pressModifiers(modifiers);
         r.typeChar(text.charAt(i), IRobot.KeyMode.PRESS_RELEASE);
-        r.releaseModifiers(modifiers);
         r.delay(pause);
       }
+      r.releaseModifiers(modifiers);
       r.typeEnds();
       profiler.lap("after typing, before waitForIdle");
       r.waitForIdle();
@@ -4343,7 +4339,7 @@ public class Region {
     return null;
   }
   //</editor-fold>
-  
+
   public String saveScreenCapture() {
     return getScreen().capture(this).save();
   }

--- a/API/src/main/java/org/sikuli/script/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/RobotDesktop.java
@@ -15,8 +15,6 @@ import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * INTERNAL USE Implementation of IRobot making a DesktopRobot using java.awt.Robot
@@ -43,7 +41,7 @@ public class RobotDesktop extends Robot implements IRobot {
   public RobotDesktop() throws AWTException {
     super();
     setAutoDelay(stdAutoDelay);
-    setAutoWaitForIdle(false);
+    setAutoWaitForIdle(true);
   }
 
   private void logRobot(int delay, String msg) {
@@ -59,7 +57,7 @@ public class RobotDesktop extends Robot implements IRobot {
     if (elapsed > maxElapsed) {
       Debug.log(0, msg, elapsed);
       setAutoDelay(stdAutoDelay);
-      setAutoWaitForIdle(false);
+      setAutoWaitForIdle(true);
     }
   }
 
@@ -78,7 +76,7 @@ public class RobotDesktop extends Robot implements IRobot {
     fakeHighlight(true);
     logRobot(stdAutoDelay, "MouseDown: WaitForIdle: %s - Delay: %d");
     setAutoDelay(stdAutoDelay);
-    setAutoWaitForIdle(false);
+    setAutoWaitForIdle(true);
     delay(100);
     fakeHighlight(false);
     delay(100);
@@ -92,7 +90,7 @@ public class RobotDesktop extends Robot implements IRobot {
   private void doMouseUp(int buttons) {
     logRobot(stdAutoDelay, "MouseUp: WaitForIdle: %s - Delay: %d");
     setAutoDelay(stdAutoDelay);
-    setAutoWaitForIdle(false);
+    setAutoWaitForIdle(true);
     mouseRelease(buttons);
     if (stdAutoDelay == 0) {
       delay(stdDelay);
@@ -103,7 +101,7 @@ public class RobotDesktop extends Robot implements IRobot {
   private void doKeyPress(KeyPress keyPress) {
       logRobot(stdAutoDelay, "KeyPress: WaitForIdle: %s - Delay: %d");
       setAutoDelay(stdAutoDelay);
-      setAutoWaitForIdle(false);
+      setAutoWaitForIdle(true);
       //press all modifiers
       keyPressSequence(keyPress.getModifiers());
       //then press all keys
@@ -115,21 +113,47 @@ public class RobotDesktop extends Robot implements IRobot {
   }
 
   /**
-   * Press a sequence of keys in one action, to enable multiple equal key inputs at the same time.
+   * Press and release a {@link KeyPress} event in the correct press-release-sequence.
+   */
+  private void doKeyPressRelease(KeyPress keyPress){
+      logRobot(stdAutoDelay, "KeyPress: WaitForIdle: %s - Delay: %d");
+      setAutoDelay(stdAutoDelay);
+      setAutoWaitForIdle(true);
+      //press all modifiers
+      keyPressSequence(keyPress.getModifiers());
+      //then press and release all keys
+      keyPressReleaseSequence(keyPress.getKeys());
+      if (stdAutoDelay == 0) {
+          delay(stdDelay);
+      }
+      keyReleaseSequence(keyPress.getModifiers());
+      logRobot("KeyPress: extended delay: %d", stdMaxElapsed);
+  }
+
+  /**
+   * Press and release a sequence of keys in one action, to enable multiple equal key inputs at the same time.
+   * @param keys arrays of int values of {@link KeyEvent}
+   */
+  private void keyPressReleaseSequence(int... keys) {
+      if (keys != null) {
+          for (int key : keys) {
+              Debug.log(4, "PRESS_KEY: " + KeyEvent.getKeyText(key));
+              keyPress(key);
+              keyRelease(key);
+              Debug.log(4, "RELEASE_KEY: " + KeyEvent.getKeyText(key));
+          }
+      }
+  }
+
+  /**
+   * Press a sequence of keys in one action.
    * @param keys arrays of int values of {@link KeyEvent}
    */
   private void keyPressSequence(int... keys) {
-      Set<Integer> pressed = new HashSet<Integer>();
       if (keys != null) {
           for (int key : keys) {
-              if (pressed.contains(key)) {
-                  //release keys to be able to typ unicode numbers with equal numbers in one action
-                  Debug.log(4,"RELEASE_KEY: " + KeyEvent.getKeyText(key));
-                  keyRelease(key);
-              }
               Debug.log(4, "PRESS_KEY: " + KeyEvent.getKeyText(key));
               keyPress(key);
-              pressed.add(key);
           }
       }
   }
@@ -137,7 +161,7 @@ public class RobotDesktop extends Robot implements IRobot {
   private void doKeyRelease(KeyPress keyPress) {
       logRobot(stdAutoDelay, "KeyRelease: WaitForIdle: %s - Delay: %d");
       setAutoDelay(stdAutoDelay);
-      setAutoWaitForIdle(false);
+      setAutoWaitForIdle(true);
       //release all keys
       keyReleaseSequence(keyPress.getKeys());
       //then release all modifiers
@@ -356,8 +380,7 @@ public class RobotDesktop extends Robot implements IRobot {
               doKeyPress(keyPress);
               break;
           case PRESS_RELEASE:
-              doKeyPress(keyPress);
-              doKeyRelease(keyPress);
+              doKeyPressRelease(keyPress);
               break;
       }
   }

--- a/API/src/main/java/org/sikuli/script/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/RobotDesktop.java
@@ -377,7 +377,7 @@ public class RobotDesktop extends Robot implements IRobot {
               doKeyPress(keyPress);
               break;
           case RELEASE_ONLY:
-              doKeyPress(keyPress);
+              doKeyRelease(keyPress);
               break;
           case PRESS_RELEASE:
               doKeyPressRelease(keyPress);

--- a/API/src/main/java/org/sikuli/script/keyboard/KeyMapping.java
+++ b/API/src/main/java/org/sikuli/script/keyboard/KeyMapping.java
@@ -1,0 +1,16 @@
+package org.sikuli.script.keyboard;
+
+/**
+ * @author tschneck
+ *         Date: 12/14/15
+ */
+public interface KeyMapping {
+
+    /**
+     * Convert Sikuli Key to Java virtual key code
+     *
+     * @param key as Character
+     * @return the Java KeyCodes
+     */
+    KeyPress lookupKeePress(char key);
+}

--- a/API/src/main/java/org/sikuli/script/keyboard/KeyMappingAlphanumeric.java
+++ b/API/src/main/java/org/sikuli/script/keyboard/KeyMappingAlphanumeric.java
@@ -1,0 +1,285 @@
+package org.sikuli.script.keyboard;
+
+import org.sikuli.script.Key;
+
+import java.awt.event.KeyEvent;
+
+/**
+ * @author tschneck
+ *         Date: 12/14/15
+ */
+public class KeyMappingAlphanumeric implements KeyMapping {
+    @Override
+    public KeyPress lookupKeePress(char key) {
+        switch (key) {
+//Lowercase
+            case 'a':
+                return new KeyPress(KeyEvent.VK_A);
+            case 'b':
+                return new KeyPress(KeyEvent.VK_B);
+            case 'c':
+                return new KeyPress(KeyEvent.VK_C);
+            case 'd':
+                return new KeyPress(KeyEvent.VK_D);
+            case 'e':
+                return new KeyPress(KeyEvent.VK_E);
+            case 'f':
+                return new KeyPress(KeyEvent.VK_F);
+            case 'g':
+                return new KeyPress(KeyEvent.VK_G);
+            case 'h':
+                return new KeyPress(KeyEvent.VK_H);
+            case 'i':
+                return new KeyPress(KeyEvent.VK_I);
+            case 'j':
+                return new KeyPress(KeyEvent.VK_J);
+            case 'k':
+                return new KeyPress(KeyEvent.VK_K);
+            case 'l':
+                return new KeyPress(KeyEvent.VK_L);
+            case 'm':
+                return new KeyPress(KeyEvent.VK_M);
+            case 'n':
+                return new KeyPress(KeyEvent.VK_N);
+            case 'o':
+                return new KeyPress(KeyEvent.VK_O);
+            case 'p':
+                return new KeyPress(KeyEvent.VK_P);
+            case 'q':
+                return new KeyPress(KeyEvent.VK_Q);
+            case 'r':
+                return new KeyPress(KeyEvent.VK_R);
+            case 's':
+                return new KeyPress(KeyEvent.VK_S);
+            case 't':
+                return new KeyPress(KeyEvent.VK_T);
+            case 'u':
+                return new KeyPress(KeyEvent.VK_U);
+            case 'v':
+                return new KeyPress(KeyEvent.VK_V);
+            case 'w':
+                return new KeyPress(KeyEvent.VK_W);
+            case 'x':
+                return new KeyPress(KeyEvent.VK_X);
+            case 'y':
+                return new KeyPress(KeyEvent.VK_Y);
+            case 'z':
+                return new KeyPress(KeyEvent.VK_Z);
+//Uppercase
+            case 'A':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_A);
+            case 'B':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_B);
+            case 'C':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_C);
+            case 'D':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_D);
+            case 'E':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_E);
+            case 'F':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_F);
+            case 'G':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_G);
+            case 'H':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_H);
+            case 'I':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_I);
+            case 'J':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_J);
+            case 'K':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_K);
+            case 'L':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_L);
+            case 'M':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_M);
+            case 'N':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_N);
+            case 'O':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_O);
+            case 'P':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_P);
+            case 'Q':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Q);
+            case 'R':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_R);
+            case 'S':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_S);
+            case 'T':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_T);
+            case 'U':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_U);
+            case 'V':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_V);
+            case 'W':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_W);
+            case 'X':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_X);
+            case 'Y':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Y);
+            case 'Z':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Z);
+//Row 3 (below function keys)
+//      case 'Press': return new Key (192}; //not producab)e
+            case '1':
+                return new KeyPress(KeyEvent.VK_1);
+            case '2':
+                return new KeyPress(KeyEvent.VK_2);
+            case '3':
+                return new KeyPress(KeyEvent.VK_3);
+            case '4':
+                return new KeyPress(KeyEvent.VK_4);
+            case '5':
+                return new KeyPress(KeyEvent.VK_5);
+            case '6':
+                return new KeyPress(KeyEvent.VK_6);
+            case '7':
+                return new KeyPress(KeyEvent.VK_7);
+            case '8':
+                return new KeyPress(KeyEvent.VK_8);
+            case '9':
+                return new KeyPress(KeyEvent.VK_9);
+            case '0':
+                return new KeyPress(KeyEvent.VK_0);
+//Numpad keys
+            case '-':
+                return new KeyPress(KeyEvent.VK_SUBTRACT);
+            case '+':
+                return new KeyPress(KeyEvent.VK_ADD);
+            case '/':
+                return new KeyPress(KeyEvent.VK_DIVIDE);
+            case '*':
+                return new KeyPress(KeyEvent.VK_MULTIPLY);
+//Special
+            case '\b':
+                return new KeyPress(KeyEvent.VK_BACK_SPACE);
+            case '\t':
+                return new KeyPress(KeyEvent.VK_TAB);
+            case '\r':
+                return new KeyPress(KeyEvent.VK_ENTER);
+            case '\n':
+                return new KeyPress(KeyEvent.VK_ENTER);
+            case ' ':
+                return new KeyPress(KeyEvent.VK_SPACE);
+//Modifier
+            case Key.C_SHIFT:
+                return new KeyPress(KeyEvent.VK_SHIFT);
+            case Key.C_CTRL:
+                return new KeyPress(KeyEvent.VK_CONTROL);
+            case Key.C_ALT:
+                return new KeyPress(KeyEvent.VK_ALT);
+            case Key.C_META:
+                return new KeyPress(KeyEvent.VK_META);
+//Cursor movement
+            case Key.C_UP:
+                return new KeyPress(KeyEvent.VK_UP);
+            case Key.C_RIGHT:
+                return new KeyPress(KeyEvent.VK_RIGHT);
+            case Key.C_DOWN:
+                return new KeyPress(KeyEvent.VK_DOWN);
+            case Key.C_LEFT:
+                return new KeyPress(KeyEvent.VK_LEFT);
+            case Key.C_PAGE_UP:
+                return new KeyPress(KeyEvent.VK_PAGE_UP);
+            case Key.C_PAGE_DOWN:
+                return new KeyPress(KeyEvent.VK_PAGE_DOWN);
+            case Key.C_END:
+                return new KeyPress(KeyEvent.VK_END);
+            case Key.C_HOME:
+                return new KeyPress(KeyEvent.VK_HOME);
+            case Key.C_DELETE:
+                return new KeyPress(KeyEvent.VK_DELETE);
+//Function keys
+            case Key.C_ESC:
+                return new KeyPress(KeyEvent.VK_ESCAPE);
+            case Key.C_F1:
+                return new KeyPress(KeyEvent.VK_F1);
+            case Key.C_F2:
+                return new KeyPress(KeyEvent.VK_F2);
+            case Key.C_F3:
+                return new KeyPress(KeyEvent.VK_F3);
+            case Key.C_F4:
+                return new KeyPress(KeyEvent.VK_F4);
+            case Key.C_F5:
+                return new KeyPress(KeyEvent.VK_F5);
+            case Key.C_F6:
+                return new KeyPress(KeyEvent.VK_F6);
+            case Key.C_F7:
+                return new KeyPress(KeyEvent.VK_F7);
+            case Key.C_F8:
+                return new KeyPress(KeyEvent.VK_F8);
+            case Key.C_F9:
+                return new KeyPress(KeyEvent.VK_F9);
+            case Key.C_F10:
+                return new KeyPress(KeyEvent.VK_F10);
+            case Key.C_F11:
+                return new KeyPress(KeyEvent.VK_F11);
+            case Key.C_F12:
+                return new KeyPress(KeyEvent.VK_F12);
+            case Key.C_F13:
+                return new KeyPress(KeyEvent.VK_F13);
+            case Key.C_F14:
+                return new KeyPress(KeyEvent.VK_F14);
+            case Key.C_F15:
+                return new KeyPress(KeyEvent.VK_F15);
+//Toggling kezs
+            case Key.C_SCROLL_LOCK:
+                return new KeyPress(KeyEvent.VK_SCROLL_LOCK);
+            case Key.C_NUM_LOCK:
+                return new KeyPress(KeyEvent.VK_NUM_LOCK);
+            case Key.C_CAPS_LOCK:
+                return new KeyPress(KeyEvent.VK_CAPS_LOCK);
+            case Key.C_INSERT:
+                return new KeyPress(KeyEvent.VK_INSERT);
+//Windows special
+            case Key.C_PAUSE:
+                return new KeyPress(KeyEvent.VK_PAUSE);
+            case Key.C_PRINTSCREEN:
+                return new KeyPress(KeyEvent.VK_PRINTSCREEN);
+//Num pad
+            case Key.C_NUM0:
+                return new KeyPress(KeyEvent.VK_NUMPAD0);
+            case Key.C_NUM1:
+                return new KeyPress(KeyEvent.VK_NUMPAD1);
+            case Key.C_NUM2:
+                return new KeyPress(KeyEvent.VK_NUMPAD2);
+            case Key.C_NUM3:
+                return new KeyPress(KeyEvent.VK_NUMPAD3);
+            case Key.C_NUM4:
+                return new KeyPress(KeyEvent.VK_NUMPAD4);
+            case Key.C_NUM5:
+                return new KeyPress(KeyEvent.VK_NUMPAD5);
+            case Key.C_NUM6:
+                return new KeyPress(KeyEvent.VK_NUMPAD6);
+            case Key.C_NUM7:
+                return new KeyPress(KeyEvent.VK_NUMPAD7);
+            case Key.C_NUM8:
+                return new KeyPress(KeyEvent.VK_NUMPAD8);
+            case Key.C_NUM9:
+                return new KeyPress(KeyEvent.VK_NUMPAD9);
+//Num pad special
+            case Key.C_SEPARATOR:
+                return new KeyPress(KeyEvent.VK_SEPARATOR);
+            case Key.C_ADD:
+                return new KeyPress(KeyEvent.VK_ADD);
+            case Key.C_MINUS:
+                return new KeyPress(KeyEvent.VK_SUBTRACT);
+            case Key.C_MULTIPLY:
+                return new KeyPress(KeyEvent.VK_MULTIPLY);
+            case Key.C_DIVIDE:
+                return new KeyPress(KeyEvent.VK_DIVIDE);
+            case Key.C_DECIMAL:
+                return new KeyPress(KeyEvent.VK_DECIMAL);
+            case Key.C_CONTEXT:
+                return new KeyPress(KeyEvent.VK_CONTEXT_MENU);
+            case Key.C_WIN:
+                return new KeyPress(KeyEvent.VK_WINDOWS);
+//hack: alternative tab in GUI
+            case Key.C_NEXT:
+                return new KeyPress(-KeyEvent.VK_TAB);
+
+            default:
+                throw new IllegalArgumentException("Cannot convert character " + key);
+        }
+
+    }
+}

--- a/API/src/main/java/org/sikuli/script/keyboard/KeyMappingAlphanumeric.java
+++ b/API/src/main/java/org/sikuli/script/keyboard/KeyMappingAlphanumeric.java
@@ -67,57 +67,57 @@ public class KeyMappingAlphanumeric implements KeyMapping {
                 return new KeyPress(KeyEvent.VK_Z);
 //Uppercase
             case 'A':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_A);
+                return new KeyPress(new int[]{KeyEvent.VK_A}, new int[]{KeyEvent.VK_SHIFT});
             case 'B':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_B);
+                return new KeyPress(new int[]{KeyEvent.VK_B}, new int[]{KeyEvent.VK_SHIFT});
             case 'C':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_C);
+                return new KeyPress(new int[]{KeyEvent.VK_C}, new int[]{KeyEvent.VK_SHIFT});
             case 'D':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_D);
+                return new KeyPress(new int[]{KeyEvent.VK_D}, new int[]{KeyEvent.VK_SHIFT});
             case 'E':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_E);
+                return new KeyPress(new int[]{KeyEvent.VK_E}, new int[]{KeyEvent.VK_SHIFT});
             case 'F':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_F);
+                return new KeyPress(new int[]{KeyEvent.VK_F}, new int[]{KeyEvent.VK_SHIFT});
             case 'G':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_G);
+                return new KeyPress(new int[]{KeyEvent.VK_G}, new int[]{KeyEvent.VK_SHIFT});
             case 'H':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_H);
+                return new KeyPress(new int[]{KeyEvent.VK_H}, new int[]{KeyEvent.VK_SHIFT});
             case 'I':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_I);
+                return new KeyPress(new int[]{KeyEvent.VK_I}, new int[]{KeyEvent.VK_SHIFT});
             case 'J':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_J);
+                return new KeyPress(new int[]{KeyEvent.VK_J}, new int[]{KeyEvent.VK_SHIFT});
             case 'K':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_K);
+                return new KeyPress(new int[]{KeyEvent.VK_K}, new int[]{KeyEvent.VK_SHIFT});
             case 'L':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_L);
+                return new KeyPress(new int[]{KeyEvent.VK_L}, new int[]{KeyEvent.VK_SHIFT});
             case 'M':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_M);
+                return new KeyPress(new int[]{KeyEvent.VK_M}, new int[]{KeyEvent.VK_SHIFT});
             case 'N':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_N);
+                return new KeyPress(new int[]{KeyEvent.VK_N}, new int[]{KeyEvent.VK_SHIFT});
             case 'O':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_O);
+                return new KeyPress(new int[]{KeyEvent.VK_O}, new int[]{KeyEvent.VK_SHIFT});
             case 'P':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_P);
+                return new KeyPress(new int[]{KeyEvent.VK_P}, new int[]{KeyEvent.VK_SHIFT});
             case 'Q':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Q);
+                return new KeyPress(new int[]{KeyEvent.VK_Q}, new int[]{KeyEvent.VK_SHIFT});
             case 'R':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_R);
+                return new KeyPress(new int[]{KeyEvent.VK_R}, new int[]{KeyEvent.VK_SHIFT});
             case 'S':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_S);
+                return new KeyPress(new int[]{KeyEvent.VK_S}, new int[]{KeyEvent.VK_SHIFT});
             case 'T':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_T);
+                return new KeyPress(new int[]{KeyEvent.VK_T}, new int[]{KeyEvent.VK_SHIFT});
             case 'U':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_U);
+                return new KeyPress(new int[]{KeyEvent.VK_U}, new int[]{KeyEvent.VK_SHIFT});
             case 'V':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_V);
+                return new KeyPress(new int[]{KeyEvent.VK_V}, new int[]{KeyEvent.VK_SHIFT});
             case 'W':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_W);
+                return new KeyPress(new int[]{KeyEvent.VK_W}, new int[]{KeyEvent.VK_SHIFT});
             case 'X':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_X);
+                return new KeyPress(new int[]{KeyEvent.VK_X}, new int[]{KeyEvent.VK_SHIFT});
             case 'Y':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Y);
+                return new KeyPress(new int[]{KeyEvent.VK_Y}, new int[]{KeyEvent.VK_SHIFT});
             case 'Z':
-                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Z);
+                return new KeyPress(new int[]{KeyEvent.VK_Z}, new int[]{KeyEvent.VK_SHIFT});
 //Row 3 (below function keys)
 //      case 'Press': return new Key (192}; //not producab)e
             case '1':
@@ -162,13 +162,13 @@ public class KeyMappingAlphanumeric implements KeyMapping {
                 return new KeyPress(KeyEvent.VK_SPACE);
 //Modifier
             case Key.C_SHIFT:
-                return new KeyPress(KeyEvent.VK_SHIFT);
+                return new KeyPress(new int[]{}, new int[]{KeyEvent.VK_SHIFT});
             case Key.C_CTRL:
-                return new KeyPress(KeyEvent.VK_CONTROL);
+                return new KeyPress(new int[]{}, new int[]{KeyEvent.VK_CONTROL});
             case Key.C_ALT:
-                return new KeyPress(KeyEvent.VK_ALT);
+                return new KeyPress(new int[]{}, new int[]{KeyEvent.VK_ALT});
             case Key.C_META:
-                return new KeyPress(KeyEvent.VK_META);
+                return new KeyPress(new int[]{}, new int[]{KeyEvent.VK_META});
 //Cursor movement
             case Key.C_UP:
                 return new KeyPress(KeyEvent.VK_UP);

--- a/API/src/main/java/org/sikuli/script/keyboard/KeyMappingMac.java
+++ b/API/src/main/java/org/sikuli/script/keyboard/KeyMappingMac.java
@@ -1,0 +1,354 @@
+package org.sikuli.script.keyboard;
+
+import org.sikuli.natives.MacUtil;
+import org.sikuli.script.Key;
+
+import java.awt.event.KeyEvent;
+
+/**
+ * Represents the default keyMapping for Mac`s if UTF-8 input isn't enabled.
+ * See {@link MacUtil#isUtf8InputSupported()}
+ *
+ * @author tschneck
+ *         Date: 12/14/15
+ */
+public class KeyMappingMac implements KeyMapping {
+    @Override
+    public KeyPress lookupKeePress(char key) {
+        switch (key) {
+//Lowercase
+            case 'a':
+                return new KeyPress(KeyEvent.VK_A);
+            case 'b':
+                return new KeyPress(KeyEvent.VK_B);
+            case 'c':
+                return new KeyPress(KeyEvent.VK_C);
+            case 'd':
+                return new KeyPress(KeyEvent.VK_D);
+            case 'e':
+                return new KeyPress(KeyEvent.VK_E);
+            case 'f':
+                return new KeyPress(KeyEvent.VK_F);
+            case 'g':
+                return new KeyPress(KeyEvent.VK_G);
+            case 'h':
+                return new KeyPress(KeyEvent.VK_H);
+            case 'i':
+                return new KeyPress(KeyEvent.VK_I);
+            case 'j':
+                return new KeyPress(KeyEvent.VK_J);
+            case 'k':
+                return new KeyPress(KeyEvent.VK_K);
+            case 'l':
+                return new KeyPress(KeyEvent.VK_L);
+            case 'm':
+                return new KeyPress(KeyEvent.VK_M);
+            case 'n':
+                return new KeyPress(KeyEvent.VK_N);
+            case 'o':
+                return new KeyPress(KeyEvent.VK_O);
+            case 'p':
+                return new KeyPress(KeyEvent.VK_P);
+            case 'q':
+                return new KeyPress(KeyEvent.VK_Q);
+            case 'r':
+                return new KeyPress(KeyEvent.VK_R);
+            case 's':
+                return new KeyPress(KeyEvent.VK_S);
+            case 't':
+                return new KeyPress(KeyEvent.VK_T);
+            case 'u':
+                return new KeyPress(KeyEvent.VK_U);
+            case 'v':
+                return new KeyPress(KeyEvent.VK_V);
+            case 'w':
+                return new KeyPress(KeyEvent.VK_W);
+            case 'x':
+                return new KeyPress(KeyEvent.VK_X);
+            case 'y':
+                return new KeyPress(KeyEvent.VK_Y);
+            case 'z':
+                return new KeyPress(KeyEvent.VK_Z);
+//Uppercase
+            case 'A':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_A);
+            case 'B':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_B);
+            case 'C':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_C);
+            case 'D':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_D);
+            case 'E':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_E);
+            case 'F':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_F);
+            case 'G':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_G);
+            case 'H':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_H);
+            case 'I':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_I);
+            case 'J':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_J);
+            case 'K':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_K);
+            case 'L':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_L);
+            case 'M':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_M);
+            case 'N':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_N);
+            case 'O':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_O);
+            case 'P':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_P);
+            case 'Q':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Q);
+            case 'R':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_R);
+            case 'S':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_S);
+            case 'T':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_T);
+            case 'U':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_U);
+            case 'V':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_V);
+            case 'W':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_W);
+            case 'X':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_X);
+            case 'Y':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Y);
+            case 'Z':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_Z);
+//Row 3 (below function keys)
+//      case '§': return new KeyPress(192}; //not producab)e
+            case '1':
+                return new KeyPress(KeyEvent.VK_1);
+            case '!':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_1);
+            case '2':
+                return new KeyPress(KeyEvent.VK_2);
+            case '@':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_2);
+            case '3':
+                return new KeyPress(KeyEvent.VK_3);
+            case '#':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_3);
+            case '4':
+                return new KeyPress(KeyEvent.VK_4);
+            case '$':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_4);
+            case '5':
+                return new KeyPress(KeyEvent.VK_5);
+            case '%':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_5);
+            case '6':
+                return new KeyPress(KeyEvent.VK_6);
+            case '^':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_6);
+            case '7':
+                return new KeyPress(KeyEvent.VK_7);
+            case '&':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_7);
+            case '8':
+                return new KeyPress(KeyEvent.VK_8);
+            case '*':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_8);
+            case '9':
+                return new KeyPress(KeyEvent.VK_9);
+            case '(':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_9);
+            case '0':
+                return new KeyPress(KeyEvent.VK_0);
+            case ')':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_0);
+            case '-':
+                return new KeyPress(KeyEvent.VK_MINUS);
+            case '_':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_MINUS);
+            case '=':
+                return new KeyPress(KeyEvent.VK_EQUALS);
+            case '+':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_EQUALS);
+//Row 2
+// q w e r t y u i o p
+            case '[':
+                return new KeyPress(KeyEvent.VK_OPEN_BRACKET);
+            case '{':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_OPEN_BRACKET);
+            case ']':
+                return new KeyPress(KeyEvent.VK_CLOSE_BRACKET);
+            case '}':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_CLOSE_BRACKET);
+//Row 1
+// a s d f g h j k l
+            case ';':
+                return new KeyPress(KeyEvent.VK_SEMICOLON);
+            case ':':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_SEMICOLON);
+            case '\'':
+                return new KeyPress(KeyEvent.VK_QUOTE);
+            case '"':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_QUOTE);
+            case '\\':
+                return new KeyPress(KeyEvent.VK_BACK_SLASH);
+            case '|':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_BACK_SLASH);
+//RETURN, BACKSPACE, TAB
+            case '\b':
+                return new KeyPress(KeyEvent.VK_BACK_SPACE);
+            case '\t':
+                return new KeyPress(KeyEvent.VK_TAB);
+            case '\r':
+                return new KeyPress(KeyEvent.VK_ENTER);
+            case '\n':
+                return new KeyPress(KeyEvent.VK_ENTER);
+//SPACE
+            case ' ':
+                return new KeyPress(KeyEvent.VK_SPACE);
+//Row 0 (first above SPACE)
+            case '`':
+                return new KeyPress(KeyEvent.VK_BACK_QUOTE);
+            case '~':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_BACK_QUOTE);
+// z x c v b n m
+            case ',':
+                return new KeyPress(KeyEvent.VK_COMMA);
+            case '<':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_COMMA);
+            case '.':
+                return new KeyPress(KeyEvent.VK_PERIOD);
+            case '>':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_PERIOD);
+            case '/':
+                return new KeyPress(KeyEvent.VK_SLASH);
+            case '?':
+                return new KeyPress(KeyEvent.VK_SHIFT, KeyEvent.VK_SLASH);
+//Modifier
+            case Key.C_SHIFT:
+                return new KeyPress(KeyEvent.VK_SHIFT);
+            case Key.C_CTRL:
+                return new KeyPress(KeyEvent.VK_CONTROL);
+            case Key.C_ALT:
+                return new KeyPress(KeyEvent.VK_ALT);
+            case Key.C_META:
+                return new KeyPress(KeyEvent.VK_META);
+//Cursor movement
+            case Key.C_UP:
+                return new KeyPress(KeyEvent.VK_UP);
+            case Key.C_RIGHT:
+                return new KeyPress(KeyEvent.VK_RIGHT);
+            case Key.C_DOWN:
+                return new KeyPress(KeyEvent.VK_DOWN);
+            case Key.C_LEFT:
+                return new KeyPress(KeyEvent.VK_LEFT);
+            case Key.C_PAGE_UP:
+                return new KeyPress(KeyEvent.VK_PAGE_UP);
+            case Key.C_PAGE_DOWN:
+                return new KeyPress(KeyEvent.VK_PAGE_DOWN);
+            case Key.C_END:
+                return new KeyPress(KeyEvent.VK_END);
+            case Key.C_HOME:
+                return new KeyPress(KeyEvent.VK_HOME);
+            case Key.C_DELETE:
+                return new KeyPress(KeyEvent.VK_DELETE);
+//Function keys
+            case Key.C_ESC:
+                return new KeyPress(KeyEvent.VK_ESCAPE);
+            case Key.C_F1:
+                return new KeyPress(KeyEvent.VK_F1);
+            case Key.C_F2:
+                return new KeyPress(KeyEvent.VK_F2);
+            case Key.C_F3:
+                return new KeyPress(KeyEvent.VK_F3);
+            case Key.C_F4:
+                return new KeyPress(KeyEvent.VK_F4);
+            case Key.C_F5:
+                return new KeyPress(KeyEvent.VK_F5);
+            case Key.C_F6:
+                return new KeyPress(KeyEvent.VK_F6);
+            case Key.C_F7:
+                return new KeyPress(KeyEvent.VK_F7);
+            case Key.C_F8:
+                return new KeyPress(KeyEvent.VK_F8);
+            case Key.C_F9:
+                return new KeyPress(KeyEvent.VK_F9);
+            case Key.C_F10:
+                return new KeyPress(KeyEvent.VK_F10);
+            case Key.C_F11:
+                return new KeyPress(KeyEvent.VK_F11);
+            case Key.C_F12:
+                return new KeyPress(KeyEvent.VK_F12);
+            case Key.C_F13:
+                return new KeyPress(KeyEvent.VK_F13);
+            case Key.C_F14:
+                return new KeyPress(KeyEvent.VK_F14);
+            case Key.C_F15:
+                return new KeyPress(KeyEvent.VK_F15);
+//Toggling kezs
+            case Key.C_SCROLL_LOCK:
+                return new KeyPress(KeyEvent.VK_SCROLL_LOCK);
+            case Key.C_NUM_LOCK:
+                return new KeyPress(KeyEvent.VK_NUM_LOCK);
+            case Key.C_CAPS_LOCK:
+                return new KeyPress(KeyEvent.VK_CAPS_LOCK);
+            case Key.C_INSERT:
+                return new KeyPress(KeyEvent.VK_INSERT);
+//Windows special
+            case Key.C_PAUSE:
+                return new KeyPress(KeyEvent.VK_PAUSE);
+            case Key.C_PRINTSCREEN:
+                return new KeyPress(KeyEvent.VK_PRINTSCREEN);
+//Num pad
+            case Key.C_NUM0:
+                return new KeyPress(KeyEvent.VK_NUMPAD0);
+            case Key.C_NUM1:
+                return new KeyPress(KeyEvent.VK_NUMPAD1);
+            case Key.C_NUM2:
+                return new KeyPress(KeyEvent.VK_NUMPAD2);
+            case Key.C_NUM3:
+                return new KeyPress(KeyEvent.VK_NUMPAD3);
+            case Key.C_NUM4:
+                return new KeyPress(KeyEvent.VK_NUMPAD4);
+            case Key.C_NUM5:
+                return new KeyPress(KeyEvent.VK_NUMPAD5);
+            case Key.C_NUM6:
+                return new KeyPress(KeyEvent.VK_NUMPAD6);
+            case Key.C_NUM7:
+                return new KeyPress(KeyEvent.VK_NUMPAD7);
+            case Key.C_NUM8:
+                return new KeyPress(KeyEvent.VK_NUMPAD8);
+            case Key.C_NUM9:
+                return new KeyPress(KeyEvent.VK_NUMPAD9);
+//Num pad special
+            case Key.C_SEPARATOR:
+                return new KeyPress(KeyEvent.VK_SEPARATOR);
+            case Key.C_ADD:
+                return new KeyPress(KeyEvent.VK_ADD);
+            case Key.C_MINUS:
+                return new KeyPress(KeyEvent.VK_SUBTRACT);
+            case Key.C_MULTIPLY:
+                return new KeyPress(KeyEvent.VK_MULTIPLY);
+            case Key.C_DIVIDE:
+                return new KeyPress(KeyEvent.VK_DIVIDE);
+            case Key.C_DECIMAL:
+                return new KeyPress(KeyEvent.VK_DECIMAL);
+            case Key.C_CONTEXT:
+                return new KeyPress(KeyEvent.VK_CONTEXT_MENU);
+            case Key.C_WIN:
+                return new KeyPress(KeyEvent.VK_WINDOWS);
+//hack: alternative tab in GUI
+            case Key.C_NEXT:
+                return new KeyPress(-KeyEvent.VK_TAB);
+
+            default:
+                throw new IllegalArgumentException(String.format(
+                        "Cannot convert character '%s'. To enable UTF-8 typing support in Mac OS X, please " +
+                                "chooses the Unicode Hex Input keyboard layout, see " +
+                                "https://en.wikipedia.org/wiki/Unicode_input#In_Mac_OS", (char) key));
+        }
+
+    }
+}

--- a/API/src/main/java/org/sikuli/script/keyboard/KeyPress.java
+++ b/API/src/main/java/org/sikuli/script/keyboard/KeyPress.java
@@ -1,0 +1,73 @@
+package org.sikuli.script.keyboard;
+
+import java.awt.event.KeyEvent;
+
+/**
+ * Represents an keyboard event which sould be executed in one action, and with possible modifiers.
+ *
+ * @author tschneck
+ *         Date: 12/16/15
+ */
+public class KeyPress {
+    private int[] keys = new int[0];
+    private int[] modifiers = new int[0];
+
+    public KeyPress(int... keys) {
+        this.keys = keys;
+    }
+
+    public KeyPress(int[] keys, int[] modifiers) {
+        this(keys);
+        this.modifiers = modifiers;
+    }
+
+    private static String printkeys(int[] keys) {
+        StringBuilder sb = new StringBuilder();
+        if (keys != null) {
+            for (int key : keys) {
+                if (sb.length() > 0) {
+                    sb.append(", ");
+                }
+                sb.append(KeyEvent.getKeyText(key));
+            }
+        }
+        return sb.toString();
+    }
+
+    public int[] getKeys() {
+        return keys;
+    }
+
+    public int[] getModifiers() {
+        return modifiers;
+    }
+
+    @Override
+    public String toString() {
+        return "(keys: " + printkeys(keys)
+                + ((modifiers.length > 0) ? ", modifiers: " + printkeys(modifiers) + ")" : "");
+    }
+
+    /**
+     * add the keypresses to current KeyPress object
+     *
+     * @param additionalKeypress a instance of {@link KeyPress}
+     */
+    public void addKeyPress(KeyPress additionalKeypress) {
+        if (additionalKeypress != null) {
+            keys = addToArray(keys, additionalKeypress.getKeys());
+            modifiers = addToArray(modifiers, additionalKeypress.getModifiers());
+        }
+    }
+
+    private int[] addToArray(int[] first, int[] second) {
+        if (first != null && second != null && second.length > 0) {
+            int[] newValue = new int[first.length + second.length];
+            System.arraycopy(first, 0, newValue, 0, first.length);
+            System.arraycopy(second, 0, newValue, first.length, second.length);
+            return newValue;
+        } else {
+            return first;
+        }
+    }
+}

--- a/API/src/main/java/org/sikuli/script/keyboard/KeyboardDelegator.java
+++ b/API/src/main/java/org/sikuli/script/keyboard/KeyboardDelegator.java
@@ -1,0 +1,99 @@
+package org.sikuli.script.keyboard;
+
+import org.sikuli.basics.Debug;
+import org.sikuli.basics.Settings;
+import org.sikuli.natives.OSUtil;
+import org.sikuli.natives.SysUtil;
+import org.sikuli.script.Key;
+
+/**
+ * Singleton implementation to get correct keyboard mapping for each supported language.
+ * See therefor all Implementations of {@link KeyMapping}.
+ *
+ * @author tschneck
+ *         Date: 12/14/15
+ */
+public class KeyboardDelegator {
+
+    private static final OSUtil _osUtil = SysUtil.getOSUtil();
+    private static KeyMapping keyMapping = null;
+
+    KeyboardDelegator() {
+        //protected constructor: use getKeyMappingInstance()
+    }
+
+    static KeyMapping getKeyMappingInstance() {
+        if (keyMapping == null) {
+            if (Settings.isMac() && !_osUtil.isUtf8InputSupported()) {
+                //macs doesn't support unicode input by default so choose the US-keyboard mapping.
+                //To active: see https://en.wikipedia.org/wiki/Unicode_input#In_Mac_OS
+                keyMapping = new KeyMappingMac();
+            } else {
+                keyMapping = new KeyMappingAlphanumeric();
+            }
+        }
+        return keyMapping;
+    }
+
+    /**
+     * Convert Sikuli Key to Java virtual key code
+     *
+     * @param key as Character
+     * @return the Java KeyCodes
+     */
+    public static KeyPress toJavaKeyCode(char key) {
+        try {
+            return getKeyMappingInstance().lookupKeePress(key);
+        } catch (IllegalArgumentException e) {
+            //if default Mac OS X key layout is active => UTF-8 wouldn't be supported
+            if (getKeyMappingInstance() instanceof KeyMappingMac){
+                throw e;
+            }
+            KeyPress result = getUnicodeKeyCombination(key);
+            Debug.log("Can't find native key mapping => use unicode input: " + result);
+            return result;
+        }
+    }
+
+    static KeyPress getUnicodeKeyCombination(char key) {
+        String keyCombo = _osUtil.getUnicodeKeyInputString(key);
+        //create base keyPress object with OS based modifier matching
+        KeyPress keyPress = new KeyPress(new int[]{}, _osUtil.getUnicodeModifier());
+        if (keyCombo != null) {
+            for (char c : keyCombo.toCharArray()) {
+                //use Numpad keys in case of an windows system
+                c = lookupNumpadKey(c);
+                keyPress.addKeyPress(getKeyMappingInstance().lookupKeePress(c));
+            }
+        }
+        return keyPress;
+    }
+
+    private static char lookupNumpadKey(char c) {
+        switch (c) {
+            case '1':
+                return Key.C_NUM1;
+            case '2':
+                return Key.C_NUM2;
+            case '3':
+                return Key.C_NUM3;
+            case '4':
+                return Key.C_NUM4;
+            case '5':
+                return Key.C_NUM5;
+            case '6':
+                return Key.C_NUM6;
+            case '7':
+                return Key.C_NUM7;
+            case '8':
+                return Key.C_NUM8;
+            case '9':
+                return Key.C_NUM9;
+            case '0':
+                return Key.C_NUM0;
+            default:
+                return c;
+        }
+    }
+
+}

--- a/API/src/test/java/org/sikuli/natives/OSUtilTest.java
+++ b/API/src/test/java/org/sikuli/natives/OSUtilTest.java
@@ -1,0 +1,32 @@
+package org.sikuli.natives;
+
+import junit.framework.TestCase;
+
+/**
+ * @author tschneck
+ *         Date: 12/15/15
+ */
+public class OSUtilTest extends TestCase {
+
+
+    public static final String[] HEX_VALUES = new String[]{"fc", "a7", "22"};
+    public static final String[] NUMERIC_VALUES = new String[]{"0252", "0167", "0034"};
+    private OSUtil osutil = SysUtil.getOSUtil() ;
+
+    public void testUtf8ToHex() throws Exception {
+        assertEquals(osutil.getUnicodeKeyInputString('ü'), getValue(0));
+        assertEquals(osutil.getUnicodeKeyInputString('§'), getValue(1));
+        assertEquals(osutil.getUnicodeKeyInputString('\"'),getValue(2));
+    }
+
+    private String getValue(int i) {
+        if (osutil instanceof WinUtil) {
+            return osutil.isUtf8InputSupported() ? HEX_VALUES[i] : NUMERIC_VALUES[i];
+        } else {
+            return HEX_VALUES[i];
+        }
+
+    }
+
+
+}

--- a/API/src/test/java/org/sikuli/script/keyboard/KeyboardDelegatorTest.java
+++ b/API/src/test/java/org/sikuli/script/keyboard/KeyboardDelegatorTest.java
@@ -1,0 +1,48 @@
+package org.sikuli.script.keyboard;
+
+import junit.framework.TestCase;
+import org.sikuli.basics.Settings;
+import org.sikuli.natives.SysUtil;
+
+import java.awt.event.KeyEvent;
+
+/**
+ * @author tschneck
+ *         Date: 12/17/15
+ */
+public class KeyboardDelegatorTest extends TestCase {
+
+    public void testUtf8KeyCombination() throws Exception {
+        KeyPress kp = KeyboardDelegator.getUnicodeKeyCombination('ü');
+        if (Settings.isWindows()) {
+            boolean utf8 = SysUtil.getOSUtil().isUtf8InputSupported();
+            assertEquals(kp.getModifiers()[0], KeyEvent.VK_ALT);
+            if (utf8) {
+                assertEquals(kp.getModifiers()[1], KeyEvent.VK_ADD);
+                assertEquals(kp.getKeys().length, 2);
+                assertEquals(kp.getKeys()[0], KeyEvent.VK_F);
+                assertEquals(kp.getKeys()[1], KeyEvent.VK_C);
+            }else {
+                assertEquals(kp.getKeys().length, 4);
+                assertEquals(kp.getKeys()[0], KeyEvent.VK_NUMPAD0);
+                assertEquals(kp.getKeys()[1], KeyEvent.VK_NUMPAD2);
+                assertEquals(kp.getKeys()[2], KeyEvent.VK_NUMPAD5);
+                assertEquals(kp.getKeys()[3], KeyEvent.VK_NUMPAD2);
+            }
+        } else if (Settings.isLinux()) {
+            assertEquals(kp.getKeys().length, 2);
+            assertEquals(kp.getKeys()[0], KeyEvent.VK_F);
+            assertEquals(kp.getKeys()[1], KeyEvent.VK_C);
+            assertEquals(kp.getModifiers().length, 3);
+            assertEquals(kp.getModifiers()[0], KeyEvent.VK_CONTROL);
+            assertEquals(kp.getModifiers()[1], KeyEvent.VK_SHIFT);
+            assertEquals(kp.getModifiers()[2], KeyEvent.VK_U);
+        } else {
+            assertEquals(kp.getKeys().length, 2);
+            assertEquals(kp.getKeys()[0], KeyEvent.VK_F);
+            assertEquals(kp.getKeys()[1], KeyEvent.VK_C);
+            assertEquals(kp.getModifiers().length, 1);
+            assertEquals(kp.getModifiers()[0], KeyEvent.VK_ALT);
+        }
+    }
+}

--- a/API/src/test/java/org/sikuli/script/keyboard/KeyboardTypingTest.java
+++ b/API/src/test/java/org/sikuli/script/keyboard/KeyboardTypingTest.java
@@ -1,0 +1,89 @@
+package org.sikuli.script.keyboard;
+
+import junit.framework.TestCase;
+import org.junit.Ignore;
+import org.sikuli.basics.Settings;
+import org.sikuli.natives.CommandExecutorHelper;
+import org.sikuli.script.App;
+import org.sikuli.script.Key;
+import org.sikuli.script.Region;
+import org.sikuli.script.Screen;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author tschneck
+ *         Date: 12/14/15
+ */
+@Ignore
+public class KeyboardTypingTest extends TestCase {
+    private App gedit;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        if(Settings.isWindows()){
+            notepad();
+        }else {
+            gedit();
+        }
+    }
+
+    private void gedit() {
+        try {
+            CommandExecutorHelper.execute("killall gedit", 0);
+        } catch (Exception e) {
+        }
+        gedit = new App("gedit").openAndWait(2);
+    }
+
+    private void notepad() {
+        try {
+            CommandExecutorHelper.execute("Taskkill /IM notepad.exe /F", 0);
+        } catch (Exception e) {
+        }
+        gedit = new App("notepad.exe").openAndWait(2);
+    }
+
+    public void testTyping() throws Exception {
+        List<String> rows = Arrays.asList(
+                "1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-0",
+                "a-b-c-d-e-f-g-h-i-j-a-b-c-d-e-f-g-h-i-j-a-b-c-d-e-f-g-h-i-j",
+                "[{zzzzz}]",
+                "haloo \"sikuli\"",
+                "haloo @consol! ᣑ",
+                "++++",
+                "ÍÍÍÍ",
+                "ϧϧϧϧϧ",
+                "/////",
+                "*111****",
+                "---\b-",
+                "zzzzz",
+                "yyyyy",
+                "\"\'\\_{}[];:;",
+                "öÖ",
+                "!\"$%&/()=?{}[]\\",
+                "!\"$%&/()=?{}[]\\",
+                "!\"§$%&/()=?{}[]\\",
+                "@€Üü+*~",
+                "ÖöÄä'#",
+                "><|µ,;:.-_",
+                ""
+        );
+
+        Region r = new Screen();
+        for (String row : rows) {
+            r.type("" + row);
+            r.type(Key.ENTER);
+        }
+        Character uml = 'ö';
+
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+//        CommandExecutorHelper.execute("killall gedit", 0);
+    }
+}


### PR DESCRIPTION
Improve typing handling:
* typing all special characters via unicode keyboard shortcuts
* keyboard mapping only contains alphanumeric characters, so region.type now will work with all local keyboards, because of typing special characters via utf-8
* Mac's currently not supports directly typing utf-8 keys, by default  see https://en.wikipedia.org/wiki/Unicode_input#In_Mac_OS. Unicode typing will only be used if correct keyboard is activated. Otherwise the "old" US-Keyboard mapping will be selected