### PR TITLE
RubyScriptRunner independent observers' callbacks call

### DIFF
--- a/API/src/main/java/org/sikuli/util/JLangHelperInterface.java
+++ b/API/src/main/java/org/sikuli/util/JLangHelperInterface.java
@@ -1,0 +1,20 @@
+package org.sikuli.util;
+
+/**
+ * This interface provides script language specific methods which are non a part
+ * of ScriptRunner classes.
+ * 
+ * These methods may be used both in case of a script running from IDE or from
+ * sikulixapi library without IDE.
+ */
+public interface JLangHelperInterface {
+    /**
+     * Run callback for observers.
+     * 
+     * @param args
+     *            is array for two elements. First is a callback object. Second
+     *            is an event.
+     * @return true if the callback was ran correctly. False in other cases.
+     */
+    public boolean runObserveCallback(Object[] args);
+}

--- a/API/src/main/java/org/sikuli/util/JRubyHelper.java
+++ b/API/src/main/java/org/sikuli/util/JRubyHelper.java
@@ -1,0 +1,56 @@
+package org.sikuli.util;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+import org.sikuli.basics.Debug;
+
+/**
+ * This class implements JRuby specific parts
+ */
+public class JRubyHelper implements JLangHelperInterface {
+    private static final String me = "JRubyHelper: ";
+
+    /**
+     * Mandatory method which returns an instance of the helper
+     * 
+     * @return
+     */
+    public static JRubyHelper get() {
+        return new JRubyHelper();
+    }
+
+    @Override
+    public boolean runObserveCallback(Object[] args) {
+        boolean result = false;
+        Object callback = args[0];
+        Object e = args[1];
+        try {
+            Class<?> rubyProcClass = callback.getClass();
+            Method getRuntime = rubyProcClass.getMethod("getRuntime", new Class<?>[0]);
+            Object runtime = getRuntime.invoke(callback, new Object[0]);
+            Class<?> runtimeClass = getRuntime.getReturnType();
+
+            Method getCurrentContext = runtimeClass.getMethod("getCurrentContext", new Class<?>[0]);
+            Object context = getCurrentContext.invoke(runtime, new Object[0]);
+
+            Class<?> jrubyUtil = Class.forName("org.jruby.javasupport.JavaUtil");
+            Method convertJavaToRuby = jrubyUtil.getMethod("convertJavaToRuby",
+                    new Class<?>[] { runtimeClass, Object.class });
+
+            Object paramForRuby = convertJavaToRuby.invoke(null, new Object[] { runtime, e });
+
+            Object iRubyObject = Array.newInstance(Class.forName("org.jruby.runtime.builtin.IRubyObject"), 1);
+            Array.set(iRubyObject, 0, paramForRuby);
+
+            Method call = rubyProcClass.getMethod("call",
+                    new Class<?>[] { context.getClass(), iRubyObject.getClass() });
+            call.invoke(callback, new Object[] { context, iRubyObject });
+            result = true;
+        } catch (Exception ex) {
+            String msg = ex.getMessage();
+            Debug.error("ObserverCallBack: problem with scripting handler: %s\n%s\n%s", me, callback, msg);
+        }
+        return result;
+    }
+}

--- a/API/src/main/java/org/sikuli/util/JythonHelper.java
+++ b/API/src/main/java/org/sikuli/util/JythonHelper.java
@@ -17,7 +17,7 @@ import org.sikuli.basics.FileManager;
 import org.sikuli.script.ImagePath;
 import org.sikuli.script.RunTime;
 
-public class JythonHelper {
+public class JythonHelper implements JLangHelperInterface {
 
   static RunTime runTime = RunTime.get();
 
@@ -319,6 +319,7 @@ public class JythonHelper {
     return true;
   }
 
+  @Override
   public boolean runObserveCallback(Object[] args) {
     PyFunction func = new PyFunction(args[0]);
     boolean success = true;

--- a/IDE/src/main/java/org/sikuli/scriptrunner/JRubyScriptRunner.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/JRubyScriptRunner.java
@@ -253,7 +253,7 @@ public class JRubyScriptRunner implements IScriptRunner {
 
   private boolean runObserveCallback(Object[] args) {
     if (runtime == null) {
-      runtime = Ruby.newInstance();
+      runtime = ((RubyProc) args[0]).getRuntime();
       context = runtime.getCurrentContext();
     }
     IRubyObject[] pargs;


### PR DESCRIPTION
Checked for Ruby scripts from IDE only!


Running from external script is impossible now:
```
./start_test.sh observer_test.rb 

observer_test.rb
[info] runcmd: lsb_release -i -r -s 
NameError: missing class or uppercase package name (`org.sikuli.script.App'), caused by (NameError) cannot link Java class org.sikuli.script.App, probable missing dependency: org/apache/commons/exec/ExecuteStreamHandler
  get_proxy_or_package_under_package at org/jruby/javasupport/JavaUtilities.java:54
                      method_missing at file:/home/rss/.rvm/rubies/jruby-1.7.19/lib/jruby.jar!/jruby/java/java_package_module_template.rb:14
                             Sikulix at /home/rss/.rvm/gems/jruby-1.7.19/gems/sikulix-1.1.0.3/lib/sikulix/sikulix.rb:37
                              (root) at /home/rss/.rvm/gems/jruby-1.7.19/gems/sikulix-1.1.0.3/lib/sikulix/sikulix.rb:7
                             require at org/jruby/RubyKernel.java:1071
                              (root) at /home/rss/.rvm/rubies/jruby-1.7.19/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
                             require at /home/rss/.rvm/rubies/jruby-1.7.19/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:54
                             require at org/jruby/RubyKernel.java:1071
                              (root) at /home/rss/.rvm/gems/jruby-1.7.19/gems/sikulix-1.1.0.3/lib/sikulix.rb:4
                              (root) at observer_test.rb:3

```

Moreover as sikulixapi is without native libs now then an additional jar usage is required. And start_test.sh looks now:
```bash
#!/usr/bin/sh

SIKULIXAPI_JAR='sikulixapi-1.1.1.jar'
SIKULIXLIBS_JAR='sikulixlibslux-1.1.1.jar'

export SIKULIXAPI_JAR
export SIKULIXLIBS_JAR

echo $1
ruby $1
```
observer_test.rb 
```ruby
require 'java'
require ENV['SIKULIXLIBS_JAR']

require 'sikulix'

include Sikulix


onAppear("1392466160677.png") { |e| popup(e.inspect, 'test1') }
```