### PR TITLE
Comment on Region.observing boolean

### DIFF
--- a/API/src/main/java/org/sikuli/script/Region.java
+++ b/API/src/main/java/org/sikuli/script/Region.java
@@ -82,7 +82,7 @@ public class Region {
   /**
    * Flag, if an observer is running on this region {@link Settings}
    */
-  private boolean observing = false;
+  private boolean observing = false; //should be AtomicBoolean instead?
   private float observeScanRate = Settings.ObserveScanRate;
   private int repeatWaitTime = Settings.RepeatWaitTime;
   /**


### PR DESCRIPTION
Hi Raiman,

I've been using the java api recently and I'm seeing some strange behavior with the observeInBackground(time) method.
What I'm seeing is that sometimes the background threads do not stop even if I call stopObserver() on the region that started observing.
I think there might be a race condition with the background observer and the value of observing, especially when running multiple background observers.
My first thought is that since the boolean 'observing' is being accessed from multiple threads perhaps it would be best to make it an AtomicBoolean?

Thanks for your hard work on this great project!