### PR TITLE
Rearrange code a bit to allow headless execution of VNC only scripts

### DIFF
--- a/API/src/main/java/org/sikuli/script/Region.java
+++ b/API/src/main/java/org/sikuli/script/Region.java
@@ -1260,7 +1260,9 @@ public class Region {
    * @return the Region being the current ROI of the containing Screen
    */
   public Region getROI() {
-    return new Region(getScreen().getRect());
+    IScreen screen = getScreen();
+    Rectangle screenRect = screen.getRect();
+    return new Region(screenRect.x, screenRect.y, screenRect.width, screenRect.height, screen);
   }
 
   // ****************************************************

--- a/API/src/main/java/org/sikuli/script/Screen.java
+++ b/API/src/main/java/org/sikuli/script/Screen.java
@@ -5,8 +5,7 @@
  */
 package org.sikuli.script;
 
-import java.awt.AWTException;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.util.Date;
 import org.sikuli.basics.Debug;
 import org.sikuli.basics.Settings;
@@ -135,7 +134,7 @@ public class Screen extends Region implements IScreen {
 
   private static void setMouseRobot() {
     try {
-      if (globalRobot == null) {
+      if (globalRobot == null && !GraphicsEnvironment.isHeadless()) {
         globalRobot = new RobotDesktop();
       }
     } catch (AWTException e) {
@@ -145,7 +144,7 @@ public class Screen extends Region implements IScreen {
 
   private IRobot getMouseRobot() {
     setMouseRobot();
-    if (null == globalRobot) {
+    if (null == globalRobot && !GraphicsEnvironment.isHeadless()) {
       log(-1, "problem getting a java.awt.Robot");
       Sikulix.endError(999);
     }

--- a/IDE/src/main/java/org/sikuli/ide/SikuliIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikuliIDE.java
@@ -234,11 +234,6 @@ public class SikuliIDE extends JFrame implements InvocationHandler {
 
     runTime = RunTime.get(RunTime.Type.IDE, args);
 
-    getInstance();
-    log(3, "running with Locale: %s", SikuliIDEI18N.getLocaleShow());
-
-    sikulixIDE.initNativeSupport();
-
     CommandArgs cmdArgs = new CommandArgs("IDE");
     cmdLine = cmdArgs.getCommandLine(CommandArgs.scanArgs(args));
 
@@ -266,6 +261,10 @@ public class SikuliIDE extends JFrame implements InvocationHandler {
       ScriptingSupport.runscript(args);
     }
 
+    getInstance();
+    log(3, "running with Locale: %s", SikuliIDEI18N.getLocaleShow());
+
+    sikulixIDE.initNativeSupport();
     sikulixIDE.ideSplash = new IDESplash(runTime);
 
     if (cmdLine.hasOption(CommandArgsEnum.DEBUG.shortname())) {


### PR DESCRIPTION
Three changes in here that allow (within certain constraints of course) execution of sikuli scripts in headless environments.
- Delay initialisation of the JFrame until after `-r` processing
- Pass the Screen object to the Region constructor in Region#getROI
- Silence errors about inability to create Robot when running in headless mode