### PR TITLE
Search entire window title in Linux findWindow()

### DIFF
--- a/API/src/main/java/org/sikuli/natives/LinuxUtil.java
+++ b/API/src/main/java/org/sikuli/natives/LinuxUtil.java
@@ -215,7 +215,7 @@ public class LinuxUtil implements OSUtil {
             String[] lines = result.getStandardOutput().split("\\n");
             for (String str : lines) {
                 //Debug.log("read: " + str);
-                String winLine[] = str.split("\\s+");
+                String winLine[] = str.split("\\s+",10);
                 boolean ok = false;
 
                 if (type == SearchType.WINDOW_ID) {
@@ -227,12 +227,12 @@ public class LinuxUtil implements OSUtil {
                         ok = true;
                     }
                 } else if (type == SearchType.APP_NAME) {
-                    String winLineName = winLine[9].toLowerCase();
+                    String winLineName = winLine[7].toLowerCase();
                     if (appName.equals(winLineName)) {
                         ok = true;
                     }
 
-                    if (!ok && winLine[7].toLowerCase().contains(appName)) {
+                    if (!ok && winLine[9].toLowerCase().contains(appName)) {
                         ok = true;
                     }
                 }


### PR DESCRIPTION
The LinuxUtil.java 'findWindow()' uses "wmctrl -lpGx" to get info
about the window.  It splits the result on any whitespace, and then
tries to match the given appName against fields 7 or 9.  However, if
the title has spaces then only the first word is in field 9.  Changing
the split to have a limit results in having the entire title
available.  Also, it makes more sense to do the 'contains' search on
field 9 (the title) rather than field 7 (the "class").